### PR TITLE
Fix/kusto connection string builder handle trailing slash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -330,3 +330,6 @@ ASALocalRun/
 .mfractor/
 
 .vscode
+package.json
+__main.js
+package-lock.json

--- a/azure-kusto-data/source/connectionBuilder.js
+++ b/azure-kusto-data/source/connectionBuilder.js
@@ -58,7 +58,7 @@ module.exports = class KustoConnectionStringBuilder {
         if (!connectionString || connectionString.trim().length === 0) throw new Error("Missing connection string");
 
         if (!!connectionString && connectionString.split(";")[0].indexOf("=") === -1) {
-            connectionString = "Data Source=" + connectionString;
+            connectionString = "Data Source=" + connectionString.replace(/\/$/, "");
         }
 
         this[KeywordMapping.authorityId.propName] = "common";

--- a/azure-kusto-data/test/connectionBuilderTest.js
+++ b/azure-kusto-data/test/connectionBuilderTest.js
@@ -4,6 +4,15 @@ const uuidv4 = require("uuid/v4");
 const KustoConnectionStringBuilder = require("../source/connectionBuilder");
 describe("KustoConnectionStringBuilder", function () {
     describe("#constructor(connectionString)", function () {
+        it("url validation", function () {
+            let kcsb1 = new KustoConnectionStringBuilder("http://cluster.region.kusto.windows.net");
+            assert.equal(kcsb1.dataSource, "http://cluster.region.kusto.windows.net");
+            let kcsb2 = new KustoConnectionStringBuilder("https://cluster.region.kusto.windows.net:443/");
+            assert.equal(kcsb2.dataSource, "https://cluster.region.kusto.windows.net:443");
+            let kcsb3 = new KustoConnectionStringBuilder("https://cluster.region.kusto.windows.net/");
+            assert.equal(kcsb3.dataSource, "https://cluster.region.kusto.windows.net");
+        });
+        
         it("from string with no creds", function () {
             let kcsbs = [
                 new KustoConnectionStringBuilder("localhost"),

--- a/azure-kusto-ingest/source/ingestClient.js
+++ b/azure-kusto-ingest/source/ingestClient.js
@@ -1,7 +1,6 @@
 const KustoClient = require("azure-kusto-data").Client;
 const { FileDescriptor, BlobDescriptor, StreamDescriptor } = require("./descriptors");
 const { ResourceManager } = require("./resourceManager");
-const { IngestionProperties } = require("./ingestionProperties");
 const IngestionBlobInfo = require("./ingestionBlobInfo");
 const uuidv4 = require("uuid/v4");
 const azureStorage = require("azure-storage");

--- a/azure-kusto-ingest/test/ingestClientTest.js
+++ b/azure-kusto-ingest/test/ingestClientTest.js
@@ -1,7 +1,7 @@
 const assert = require("assert");
 
 const KustoIngestClient = require("../source/ingestClient");
-
+const { IngestionProperties } = require("../source/ingestionProperties");
 
 describe("KustoIngestClient", function () {
     describe("#constructor()", function () {
@@ -16,6 +16,53 @@ describe("KustoIngestClient", function () {
             assert.equal(ingestClient.defaultProps.database, "db");
             assert.equal(ingestClient.defaultProps.table, "table");
             assert.equal(ingestClient.defaultProps.format, "csv");
+        });
+    });
+
+    describe("#_resolveProperties()", function () {
+        it("empty default props", function () {
+            let newProps = new IngestionProperties("db", "table", "csv");
+            // TODO: not sure a unit test will be useful here
+            let client = new KustoIngestClient('https://cluster.region.kusto.windows.net');
+            let actual = client._mergeProps(newProps);
+
+            assert.equal(actual.database, "db");
+            assert.equal(actual.table, "table");
+            assert.equal(actual.format, "csv");
+        });
+
+        it("empty new props", function () {
+            // TODO: not sure a unit test will be useful here
+            let defaultProps = new IngestionProperties("db", "table", "csv");
+            // TODO: not sure a unit test will be useful here
+            let client = new KustoIngestClient('https://cluster.region.kusto.windows.net', defaultProps);
+            let actual = client._mergeProps(null);
+
+            assert.equal(actual.database, "db");
+            assert.equal(actual.table, "table");
+            assert.equal(actual.format, "csv");
+        });
+
+        it("both exist props", function () {
+            let defaultProps = new IngestionProperties("db", "table", "csv");
+            let newProps = new IngestionProperties();
+            newProps.database = "db2";
+            newProps.mappingReference = "MappingRef";
+
+            let client = new KustoIngestClient('https://cluster.region.kusto.windows.net', defaultProps);
+            let actual = client._mergeProps(newProps);
+
+            assert.equal(actual.database, "db2");
+            assert.equal(actual.table, "table");
+            assert.equal(actual.format, "csv");
+            assert.equal(actual.mappingReference, "MappingRef");
+        });
+
+        it("empty both", function () {
+            let client = new KustoIngestClient('https://cluster.region.kusto.windows.net');
+
+            let actual = client._mergeProps();
+            assert.equal(actual, undefined);
         });
     });
 


### PR DESCRIPTION
fix for https://github.com/Azure/azure-kusto-node/issues/7

remove trailing slash + test

P.S. 
Chose this simple method instead of complex url validation because localhost and other edge case are currently supported which are not valid urls (by strict definitions) and I don't want to break compatibility