### PR TITLE
Added support to AAD Managed Identities

### DIFF
--- a/azure-kusto-data/README.md
+++ b/azure-kusto-data/README.md
@@ -24,8 +24,8 @@ client.execute("db", "TableName | limit 1", (err, results) => {
 ## Authentication
 There are several authentication methods
 
-### AAD appliction
-There are two ways to authenticate using AAD application:
+### AAD application
+There are three ways to authenticate using AAD application:
 Option 1: Authenticating using AAD application id and corresponding key.
 ```javascript
 const kcsb = KustoConnectionStringBuilder.withAadApplicationKeyAuthentication(`https://${clusterName}.kusto.windows.net`,'appid','appkey','authorityId');
@@ -35,6 +35,12 @@ Option 2: Authenticating using AAD application id and corresponding certificate.
 
 ```javascript
 const kcsb = KustoConnectionStringBuilder.withAadApplicationCertificateAuthentication(`https://${clusterName}.kusto.windows.net`, 'appid', 'certificate', 'thumbprint', 'authorityId');
+```
+
+Option 3: Authenticating using AAD Managed Identities.
+
+```javascript
+const kcsb = KustoConnectionStringBuilder.withAadManagedIdentities(`https://${clusterName}.kusto.windows.net`, 'msi_endpoint', 'msi_secret');
 ```
 
 

--- a/azure-kusto-data/package.json
+++ b/azure-kusto-data/package.json
@@ -25,12 +25,12 @@
   "license": "ISC",
   "dependencies": {
     "adal-node": "^0.1.28",
-    "eslint": "^6.0.1",
     "moment": "^2.22.2",
     "request": "^2.88.0",
     "uuid": "^3.3.2"
   },
   "devDependencies": {
+    "eslint": "^6.0.1",
     "mocha": "^5.2.0",
     "sinon": "^7.2.3"
   }

--- a/azure-kusto-data/package.json
+++ b/azure-kusto-data/package.json
@@ -25,6 +25,7 @@
   "license": "ISC",
   "dependencies": {
     "adal-node": "^0.1.28",
+    "eslint": "^6.0.1",
     "moment": "^2.22.2",
     "request": "^2.88.0",
     "uuid": "^3.3.2"

--- a/azure-kusto-data/source/connectionBuilder.js
+++ b/azure-kusto-data/source/connectionBuilder.js
@@ -39,6 +39,16 @@ const KeywordMapping = Object.freeze({
         mappedTo: "Authority Id",
         validNames: ["authority id", "authorityid", "authority", "tenantid", "tenant", "tid"]
     },
+    msi_endpoint: {
+        propName: "msi_endpoint",
+        mappedTo: "msi_endpoint",
+        validNames: ["msi_endpoint"]
+    },
+    msi_secret: {
+        propName: "msi_secret",
+        mappedTo: "msi_secret",
+        validNames: ["msi_secret"]
+    }
 });
 
 const getPropName = (key) => {
@@ -113,6 +123,17 @@ module.exports = class KustoConnectionStringBuilder {
         const kcsb = new KustoConnectionStringBuilder(connectionString);
         kcsb[KeywordMapping.authorityId.propName] = authorityId;
         kcsb.AuthorizationCallback = authCallback;
+
+        return kcsb;
+    }
+
+    static withAadManagedIdentities(connectionString, msi_endpoint, msi_secret) {
+        if (!msi_endpoint || msi_endpoint.trim().length == 0) throw new Error("Invalid endpoint");
+        if (!msi_secret || msi_secret.trim().length == 0) throw new Error("Invalid secret");
+
+        const kcsb = new KustoConnectionStringBuilder(connectionString);
+        kcsb[KeywordMapping.msi_endpoint.propName] = msi_endpoint;
+        kcsb[KeywordMapping.msi_secret.propName] = msi_secret;
 
         return kcsb;
     }

--- a/azure-kusto-data/source/connectionBuilder.js
+++ b/azure-kusto-data/source/connectionBuilder.js
@@ -39,15 +39,15 @@ const KeywordMapping = Object.freeze({
         mappedTo: "Authority Id",
         validNames: ["authority id", "authorityid", "authority", "tenantid", "tenant", "tid"]
     },
-    msi_endpoint: {
-        propName: "msi_endpoint",
+    msiEndpoint: {
+        propName: "msiEndpoint",
         mappedTo: "msi_endpoint",
-        validNames: ["msi_endpoint"]
+        validNames: ["msi_endpoint", "msiendpoint"]
     },
-    msi_secret: {
-        propName: "msi_secret",
+    msiSecret: {
+        propName: "msiSecret",
         mappedTo: "msi_secret",
-        validNames: ["msi_secret"]
+        validNames: ["msi_secret", "msisecret"]
     }
 });
 
@@ -127,13 +127,13 @@ module.exports = class KustoConnectionStringBuilder {
         return kcsb;
     }
 
-    static withAadManagedIdentities(connectionString, msi_endpoint, msi_secret) {
-        if (!msi_endpoint || msi_endpoint.trim().length == 0) throw new Error("Invalid endpoint");
-        if (!msi_secret || msi_secret.trim().length == 0) throw new Error("Invalid secret");
+    static withAadManagedIdentities(connectionString, msiEndpoint, msiSecret) {
+        if (!msiEndpoint || msiEndpoint.trim().length == 0) throw new Error("Invalid endpoint");
+        if (!msiSecret || msiSecret.trim().length == 0) throw new Error("Invalid secret");
 
         const kcsb = new KustoConnectionStringBuilder(connectionString);
-        kcsb[KeywordMapping.msi_endpoint.propName] = msi_endpoint;
-        kcsb[KeywordMapping.msi_secret.propName] = msi_secret;
+        kcsb[KeywordMapping.msiEndpoint.propName] = msiEndpoint;
+        kcsb[KeywordMapping.msiSecret.propName] = msiSecret;
 
         return kcsb;
     }

--- a/azure-kusto-data/source/managedIdentitiesClient.js
+++ b/azure-kusto-data/source/managedIdentitiesClient.js
@@ -1,0 +1,39 @@
+const http = require("http");
+const url = require("url");
+
+module.exports = function acquireToken(resource, msi_endpoint, msi_secret, callback) {
+    const msiResource = `${msi_endpoint}/?resource=${resource}&api-version=2017-09-01`;
+    const msiUrl = url.parse(msiResource);
+
+    const options = {
+        host: msiUrl.host,
+        hostname: msiUrl.hostname,
+        port: msiUrl.port,
+        path: msiUrl.path,
+        headers: {
+            secret: msi_secret
+        }
+    };
+
+    const request = http.request(options, res => {
+        let data = "";
+
+        res.on("data", chunk => {
+            data += chunk;
+        });
+
+        res.on("end", () => {
+            let responseData = JSON.parse(data);
+            responseData.tokenType = responseData.token_type;
+            responseData.accessToken = responseData.access_token;
+
+            return callback(null, responseData);
+        });
+    });
+
+    request.on("error", err => {
+        return callback(err);
+    });
+
+    request.end();
+};

--- a/azure-kusto-data/source/managedIdentitiesClient.js
+++ b/azure-kusto-data/source/managedIdentitiesClient.js
@@ -1,8 +1,8 @@
 const http = require("http");
 const url = require("url");
 
-module.exports = function acquireToken(resource, msi_endpoint, msi_secret, callback) {
-    const msiResource = `${msi_endpoint}/?resource=${resource}&api-version=2017-09-01`;
+module.exports = function acquireToken(resource, msiEndpoint, msiSecret, callback) {
+    const msiResource = `${msiEndpoint}/?resource=${resource}&api-version=2017-09-01`;
     const msiUrl = url.parse(msiResource);
 
     const options = {
@@ -11,7 +11,7 @@ module.exports = function acquireToken(resource, msi_endpoint, msi_secret, callb
         port: msiUrl.port,
         path: msiUrl.path,
         headers: {
-            secret: msi_secret
+            secret: msiSecret
         }
     };
 

--- a/azure-kusto-data/source/security.js
+++ b/azure-kusto-data/source/security.js
@@ -43,11 +43,11 @@ module.exports = class AadHelper {
             this.clientId = kcsb.applicationClientId;
             this.certificate = kcsb.applicationCertificate;
             this.thumbprint = kcsb.applicationCertificateThumbprint;
-        } else if (!!kcsb.msi_endpoint && !!kcsb.msi_secret) {
+        } else if (!!kcsb.msiEndpoint && !!kcsb.msiSecret) {
             this.authMethod = AuthenticationMethod.managedIdentities;
             this.clientId = "db662dc1-0cfe-4e1c-a843-19a68e65be58";
-            this.msi_endpoint = kcsb.msi_endpoint;
-            this.msi_secret = kcsb.msi_secret;
+            this.msiEndpoint = kcsb.msiEndpoint;
+            this.msiSecret = kcsb.msiSecret;
             this.apiVersion = "2017-09-01";
         } else {
             this.authMethod = AuthenticationMethod.deviceLogin;
@@ -101,7 +101,7 @@ module.exports = class AadHelper {
                     }
                 });
             case AuthenticationMethod.managedIdentities:
-                return msiAcquireToken(resource, this.msi_endpoint, this.msi_secret, (err, tokenResponse) => {
+                return msiAcquireToken(resource, this.msiEndpoint, this.msiSecret, (err, tokenResponse) => {
                     if(err) {
                         return cb(err);
                     }

--- a/azure-kusto-data/source/security.js
+++ b/azure-kusto-data/source/security.js
@@ -1,11 +1,13 @@
 
 const { AuthenticationContext } = require("adal-node");
+const msiAcquireToken = require("./managedIdentitiesClient");
 
 const AuthenticationMethod = Object.freeze({
     username: 0,
     appKey: 1,
     appCertificate: 2,
-    deviceLogin: 3
+    deviceLogin: 3,
+    managedIdentities: 4
 });
 
 
@@ -15,13 +17,13 @@ module.exports = class AadHelper {
 
         let authority = kcsb.authorityId || "common";
         let url;
-        
+
         // support node compatability
         try {
             url = new URL(kcsb.dataSource);
-        } catch (e){            
+        } catch (e) {
             const URL = require("url").URL;
-            url = new URL(kcsb.dataSource);            
+            url = new URL(kcsb.dataSource);
         }
 
         this.kustoCluster = `${url.protocol}//${url.hostname}`;
@@ -41,6 +43,12 @@ module.exports = class AadHelper {
             this.clientId = kcsb.applicationClientId;
             this.certificate = kcsb.applicationCertificate;
             this.thumbprint = kcsb.applicationCertificateThumbprint;
+        } else if (!!kcsb.msi_endpoint && !!kcsb.msi_secret) {
+            this.authMethod = AuthenticationMethod.managedIdentities;
+            this.clientId = "db662dc1-0cfe-4e1c-a843-19a68e65be58";
+            this.msi_endpoint = kcsb.msi_endpoint;
+            this.msi_secret = kcsb.msi_secret;
+            this.apiVersion = "2017-09-01";
         } else {
             this.authMethod = AuthenticationMethod.deviceLogin;
             this.clientId = "db662dc1-0cfe-4e1c-a843-19a68e65be58";
@@ -91,6 +99,14 @@ module.exports = class AadHelper {
                         });
 
                     }
+                });
+            case AuthenticationMethod.managedIdentities:
+                return msiAcquireToken(resource, this.msi_endpoint, this.msi_secret, (err, tokenResponse) => {
+                    if(err) {
+                        return cb(err);
+                    }
+
+                    return cb(err, tokenResponse && formatHeader(tokenResponse));
                 });
             default:
                 return cb("Couldn't Authenticate, something went wrong trying to choose authentication method");

--- a/azure-kusto-data/test/connectionBuilderTest.js
+++ b/azure-kusto-data/test/connectionBuilderTest.js
@@ -79,6 +79,28 @@ describe("KustoConnectionStringBuilder", function () {
                 }
             }
         });
+
+        it("from aad managed indentities", function() {
+            const msi_endpoint = "anEndpoint";
+            const msi_secret = "aSecretString";
+
+            let kcsbs = [
+                new KustoConnectionStringBuilder(`localhost;msi_endpoint=${msi_endpoint};msi_secret=${msi_secret}`),
+                KustoConnectionStringBuilder.withAadManagedIdentities("localhost", msi_endpoint, msi_secret)
+            ];
+
+            for(let kcsb of kcsbs) {
+                assert.equal(kcsb.dataSource, "localhost");
+                assert.equal(kcsb.msi_endpoint, msi_endpoint);
+                assert.equal(kcsb.msi_secret, msi_secret);
+                assert.equal(kcsb.authorityId, "common");
+                let emptyFields = ["aadUserId", "password", "applicationClientId", "applicationKey"];
+                for (let field of emptyFields) {
+                    assert.equal(kcsb[field], null);
+                }
+            }
+        });
     });
 });
+
 

--- a/azure-kusto-data/test/connectionBuilderTest.js
+++ b/azure-kusto-data/test/connectionBuilderTest.js
@@ -81,18 +81,19 @@ describe("KustoConnectionStringBuilder", function () {
         });
 
         it("from aad managed indentities", function() {
-            const msi_endpoint = "anEndpoint";
-            const msi_secret = "aSecretString";
+            const msiEndpoint = "anEndpoint";
+            const msiSecret = "aSecretString";
 
             let kcsbs = [
-                new KustoConnectionStringBuilder(`localhost;msi_endpoint=${msi_endpoint};msi_secret=${msi_secret}`),
-                KustoConnectionStringBuilder.withAadManagedIdentities("localhost", msi_endpoint, msi_secret)
+                new KustoConnectionStringBuilder(`localhost;msi_endpoint=${msiEndpoint};msi_secret=${msiSecret}`),
+                new KustoConnectionStringBuilder(`localhost;msiEndpoint=${msiEndpoint};msiSecret=${msiSecret}`),
+                KustoConnectionStringBuilder.withAadManagedIdentities("localhost", msiEndpoint, msiSecret)
             ];
 
             for(let kcsb of kcsbs) {
                 assert.equal(kcsb.dataSource, "localhost");
-                assert.equal(kcsb.msi_endpoint, msi_endpoint);
-                assert.equal(kcsb.msi_secret, msi_secret);
+                assert.equal(kcsb.msiEndpoint, msiEndpoint);
+                assert.equal(kcsb.msiSecret, msiSecret);
                 assert.equal(kcsb.authorityId, "common");
                 let emptyFields = ["aadUserId", "password", "applicationClientId", "applicationKey"];
                 for (let field of emptyFields) {


### PR DESCRIPTION
This PR adds support for querying Kusto using AAD Managed Identities. Here's some documentation for implementation detail: [Overview Managed Identity](https://docs.microsoft.com/en-us/azure/app-service/overview-managed-identity#using-the-rest-protocol)