### PR TITLE
Add parameters to clientRequestProperties

### DIFF
--- a/azure-kusto-data/README.md
+++ b/azure-kusto-data/README.md
@@ -85,10 +85,15 @@ For more fine grained control, we expose `ClientRequestProperties`.
 const ClientRequestProperties = require("azure-kusto-data").ClientRequestProperties;
 const Client = require("azure-kusto-data").Client;
 
-let client = new Client("http://cluster.region.kusto.windows.net");
-let clientRequestProps = new ClientRequestProperties();
+const client = new Client("http://cluster.region.kusto.windows.net");
+const query = `
+declare query_parameters(amount:long);
+T | where amountColumn == amount
+`;
+const clientRequestProps = new ClientRequestProperties();
 clientRequestProps.setOption("servertimeout", 1000 * 60);
-client.executeQuery("db","Table | count", (err, results) => { console.log(results);}, clientRequestProps);
+clientRequestProps.setParamter("amount", 100);
+client.executeQuery("db",query, (err, results) => { console.log(results); }, clientRequestProps);
 ```
 
 A full list of those properties can be found at https://docs.microsoft.com/en-us/azure/kusto/api/netfx/request-properties

--- a/azure-kusto-data/README.md
+++ b/azure-kusto-data/README.md
@@ -92,8 +92,8 @@ T | where amountColumn == amount
 `;
 const clientRequestProps = new ClientRequestProperties();
 clientRequestProps.setOption("servertimeout", 1000 * 60);
-clientRequestProps.setParamter("amount", 100);
-client.executeQuery("db",query, (err, results) => { console.log(results); }, clientRequestProps);
+clientRequestProps.setParameter("amount", 100);
+client.executeQuery("db", query, (err, results) => { console.log(results); }, clientRequestProps);
 ```
 
 A full list of those properties can be found at https://docs.microsoft.com/en-us/azure/kusto/api/netfx/request-properties

--- a/azure-kusto-data/source/clientRequestProperties.js
+++ b/azure-kusto-data/source/clientRequestProperties.js
@@ -1,6 +1,7 @@
 module.exports = class ClientRequestProperties {
-    constructor() {
-        this._options = {};      
+    constructor(options, parameters) {
+        this._options = options || {};
+        this._parameters = parameters || {};
     }
 
     setOption(name, value) {
@@ -12,6 +13,22 @@ module.exports = class ClientRequestProperties {
             return defaultValue;
 
         return this._options[name];
+    }
+
+    setParameter(name, value) {
+        this._parameters[name] = value;
+    }
+
+    getParameter(name, defaultValue) {
+        if (!this._parameters || this._parameters[name] === undefined) {
+            return defaultValue;
+        }
+
+        return this._parameters[name];
+    }
+
+    clearParameter() {
+        this._parameters = {};
     }
 
     setTimeout(timeoutMillis) {
@@ -27,11 +44,17 @@ module.exports = class ClientRequestProperties {
     }
 
     toJson() {
-        if (!this._options || Object.keys(this._options).length == 0) {
-            return null;
+        let json = {};
+
+        if (Object.keys(this._options).length !== 0) {
+            json.Options = this._options;
         }
 
-        return { "Options" : this._options };
+        if (Object.keys(this._parameters).length !== 0) {
+            json.Parameters = this._parameters;
+        }
+
+        return Object.keys(json).length !== 0 ? json : null;
     }
 
     toString() {

--- a/azure-kusto-data/source/clientRequestProperties.js
+++ b/azure-kusto-data/source/clientRequestProperties.js
@@ -27,7 +27,7 @@ module.exports = class ClientRequestProperties {
         return this._parameters[name];
     }
 
-    clearParameter() {
+    clearParameters() {
         this._parameters = {};
     }
 


### PR DESCRIPTION
Adds the `Parameters` property to ClientRequestProperties class.

Documentation about it: https://docs.microsoft.com/en-us/azure/kusto/query/queryparametersstatement