### PR TITLE
fix TypeError: 'Cannot read property 'primaryResults' of null'

### DIFF
--- a/azure-kusto-ingest/source/resourceManager.js
+++ b/azure-kusto-ingest/source/resourceManager.js
@@ -103,7 +103,7 @@ module.exports.ResourceManager = class ResourceManager {
 
     getIngestClientResourcesFromService(callback) {
         return this.kustoClient.execute("NetDefaultDB", ".get ingestion resources", (err, resp) => {
-            if (err) callback(err);
+            if (err) return callback(err);
 
             const table = resp.primaryResults[0];
 

--- a/azure-kusto-ingest/test/resourceManagerTest.js
+++ b/azure-kusto-ingest/test/resourceManagerTest.js
@@ -91,6 +91,36 @@ describe("ResourceManager", function () {
                 done();
             });
         });
+
+        it("error response", function(done){
+            const client = new KustoClient("https://cluster.kusto.windows.net");
+
+            sinon.replace(client, "execute", (db, query, callback) => {
+                return callback("Kusto request erred (403)", null);
+            });
+
+            const resourceManager = new ResourceManager(client);
+
+            resourceManager.getIngestClientResourcesFromService((err, resources) => {
+                assert.equal(err, "Kusto request erred (403)");
+                assert.equal(resources, undefined);
+                done();
+            });
+        });
+
+        it("no exceptions after callback", function() {
+            const client = new KustoClient("https://cluster.kusto.windows.net");
+
+            sinon.replace(client, "execute", (db, query, callback) => {
+                return callback("Kusto request erred (403)", null);
+            });
+
+            const resourceManager = new ResourceManager(client);
+
+            const response = resourceManager.getIngestClientResourcesFromService(() => true);
+
+            assert.ok(response)
+        });
     });
 
     describe("#getResourceByName()", function () {


### PR DESCRIPTION
when kusto client response with http error