### PR TITLE
Update path check

### DIFF
--- a/azure-kusto-data/source/client.js
+++ b/azure-kusto-data/source/client.js
@@ -121,15 +121,15 @@ module.exports = class KustoClient {
 
         const { raw } = properties || {};
         const path = response.request.path.toLowerCase();
-        if (raw === true || path.startsWith("/v1/rest/ingest")) {
+        if (raw === true || path.includes("/v1/rest/ingest")) {
             return response.data;
         }
 
         let kustoResponse = null;
         try {
-            if (path.startsWith("/v2/")) {
+            if (path.includes("/v2/")) {
                 kustoResponse = new KustoResponseDataSetV2(response.data);
-            } else if (path.startsWith("/v1/")) {
+            } else if (path.includes("/v1/")) {
                 kustoResponse = new KustoResponseDataSetV1(response.data);
             }
         } catch (ex) {


### PR DESCRIPTION
Updated to support PlayFab  where  Insights  uses a proxy passing  '/[titleid]/'  in the path on the URL.

#### Pull Request Description

PlayFab has a title id and a non standard URL that doesn't use a default Kusto enpoint, but rather a proxy  https://insights.playfab.com/[titleid].   This change allows supporting the endpoint by checking with includes instead of 'startsWith'

---

#### Future Release Comment
_[Add description of your change, to include in the next release]_
_[Delete any or all irrelevant sections, e.g. if your change does not warrant a release comment at all]_

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- None
