### PR TITLE
Parse response according to execution type

### DIFF
--- a/azure-kusto-data/package-lock.json
+++ b/azure-kusto-data/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-kusto-data",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/azure-kusto-data/package.json
+++ b/azure-kusto-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-kusto-data",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Azure Data Explorer Query SDK",
   "main": "index.js",
   "engines": {

--- a/azure-kusto-data/source/client.js
+++ b/azure-kusto-data/source/client.js
@@ -15,6 +15,12 @@ const QUERY_TIMEOUT_IN_MILLISECS = moment.duration(4.5, "minutes").asMillisecond
 const CLIENT_SERVER_DELTA_IN_MILLISECS = moment.duration(0.5, "minutes").asMilliseconds();
 const MGMT_PREFIX = ".";
 
+const ExecutionType = Object.freeze({
+    Mgmt: 0,
+    Query: 1,
+    ingest: 2
+});
+
 module.exports = class KustoClient {
     constructor(kcsb) {
         this.connectionString = typeof (kcsb) === "string" ? new ConnectionStringBuilder(kcsb) : kcsb;
@@ -42,11 +48,11 @@ module.exports = class KustoClient {
     }
 
     async executeQuery(db, query, properties) {
-        return this._execute(this.endpoints.query, db, query, null, properties);
+        return this._execute(this.endpoints.query, ExecutionType.Query, db, query, null, properties);
     }
 
     async executeMgmt(db, query, properties) {
-        return this._execute(this.endpoints.mgmt, db, query, null, properties);
+        return this._execute(this.endpoints.mgmt, ExecutionType.Mgmt, db, query, null, properties);
     }
 
     async executeStreamingIngest(db, table, stream, streamFormat, mappingName) {
@@ -55,10 +61,10 @@ module.exports = class KustoClient {
             endpoint += `&mappingName=${mappingName}`;
         }
 
-        return this._execute(endpoint, db, null, stream, null);
+        return this._execute(endpoint, ExecutionType.Ingest, db, null, stream, null);
     }
 
-    async _execute(endpoint, db, query, stream, properties) {
+    async _execute(endpoint, executionType, db, query, stream, properties) {
         const headers = {};
         Object.assign(headers, this.headers);
 
@@ -66,7 +72,7 @@ module.exports = class KustoClient {
         let clientRequestPrefix = "";
         let clientRequestId;
 
-        let timeout = this._getClientTimeout(endpoint, properties);
+        let timeout = this._getClientTimeout(executionType, properties);
 
         if (query != null) {
             payload = {
@@ -93,10 +99,10 @@ module.exports = class KustoClient {
 
         headers["Authorization"] = await this.aadHelper._getAuthHeader();
 
-        return this._doRequest(endpoint, headers, payload, timeout, properties);
+        return this._doRequest(endpoint, executionType, headers, payload, timeout, properties);
     }
 
-    async _doRequest(endpoint, headers, payload, timeout, properties) {
+    async _doRequest(endpoint, executionType, headers, payload, timeout, properties) {
         let axiosConfig = {
             headers: headers,
             gzip: true,
@@ -114,23 +120,22 @@ module.exports = class KustoClient {
             throw error;
         }
 
-        return this._parseResponse(axiosResponse, properties);
+        return this._parseResponse(axiosResponse.data, executionType, properties);
     }
 
-    _parseResponse(response, properties) {
+    _parseResponse(response, executionType, properties) {
 
         const { raw } = properties || {};
-        const path = response.request.path.toLowerCase();
-        if (raw === true || path.startsWith("/v1/rest/ingest")) {
-            return response.data;
+        if (raw === true || executionType == ExecutionType.Ingest) {
+            return response;
         }
 
         let kustoResponse = null;
         try {
-            if (path.startsWith("/v2/")) {
-                kustoResponse = new KustoResponseDataSetV2(response.data);
-            } else if (path.startsWith("/v1/")) {
-                kustoResponse = new KustoResponseDataSetV1(response.data);
+            if (executionType == ExecutionType.Query) {
+                kustoResponse = new KustoResponseDataSetV2(response);
+            } else {
+                kustoResponse = new KustoResponseDataSetV1(response);
             }
         } catch (ex) {
             throw `Failed to parse response ({${response.status}}) with the following error [${ex}].`;
@@ -141,20 +146,20 @@ module.exports = class KustoClient {
         return kustoResponse;
     }
 
-    _getClientTimeout(endpoint, properties) {
+    _getClientTimeout(executionType, properties) {
         if (properties != null && properties instanceof ClientRequestProperties) {
             const clientTimeout = properties.getClientTimeout();
-            if(clientTimeout){
+            if (clientTimeout) {
                 return clientTimeout;
             }
 
             const serverTimeout = properties.getTimeout();
-            if(serverTimeout){
+            if (serverTimeout) {
                 return serverTimeout + CLIENT_SERVER_DELTA_IN_MILLISECS;
             }
         }
 
-        const defaultTimeout = endpoint == this.endpoints.query ? QUERY_TIMEOUT_IN_MILLISECS : COMMAND_TIMEOUT_IN_MILLISECS;
+        const defaultTimeout = executionType == ExecutionType.Query ? QUERY_TIMEOUT_IN_MILLISECS : COMMAND_TIMEOUT_IN_MILLISECS;
         return defaultTimeout;
     }
 };

--- a/azure-kusto-data/source/client.js
+++ b/azure-kusto-data/source/client.js
@@ -18,7 +18,7 @@ const MGMT_PREFIX = ".";
 const ExecutionType = Object.freeze({
     Mgmt: 0,
     Query: 1,
-    ingest: 2
+    Ingest: 2
 });
 
 module.exports = class KustoClient {

--- a/azure-kusto-data/test/clientTest.js
+++ b/azure-kusto-data/test/clientTest.js
@@ -16,7 +16,7 @@ const KustoClientRequestProperties = require("../source/clientRequestProperties"
 const ExecutionType = Object.freeze({
     Mgmt: 0,
     Query: 1,
-    ingest: 2
+    Ingest: 2
 });
 
 describe("KustoClient", function () {

--- a/azure-kusto-data/test/clientTest.js
+++ b/azure-kusto-data/test/clientTest.js
@@ -13,6 +13,12 @@ const sinon = require("sinon");
 const KustoClient = require("../source/client");
 const KustoClientRequestProperties = require("../source/clientRequestProperties");
 
+const ExecutionType = Object.freeze({
+    Mgmt: 0,
+    Query: 1,
+    ingest: 2
+});
+
 describe("KustoClient", function () {
     describe("#constructor", function () {
         it("valid", function () {
@@ -32,7 +38,7 @@ describe("KustoClient", function () {
             let url = "https://cluster.kusto.windows.net";
             let client = new KustoClient(url);
 
-            const response = client._parseResponse({ request: { path: "/v1/mgmt/" }, data: v1Response });
+            const response = client._parseResponse(v1Response, ExecutionType.Mgmt);
             assert.equal(response.version, "1.0");
         });
 
@@ -40,7 +46,7 @@ describe("KustoClient", function () {
             let url = "https://cluster.kusto.windows.net";
             let client = new KustoClient(url);
 
-            const response = client._parseResponse({ request: { path: "/v1/mgmt/" }, data: v1_2Response });
+            const response = client._parseResponse(v1_2Response, ExecutionType.Mgmt);
             assert.equal(response.version, "1.0");
         });
 
@@ -49,7 +55,7 @@ describe("KustoClient", function () {
             let client = new KustoClient(url);
 
 
-            const response = client._parseResponse({ request: { path: "/v2/query/" }, data: v2Response });
+            const response = client._parseResponse(v2Response, ExecutionType.Query);
             assert.equal(response.version, "2.0");
         });
 
@@ -57,7 +63,7 @@ describe("KustoClient", function () {
             let url = "https://cluster.kusto.windows.net";
             let client = new KustoClient(url);
 
-            const response = client._parseResponse({ request: { path: "/v2/query/" }, data: v2Response }, { raw: true });
+            const response = client._parseResponse(v2Response, ExecutionType.Query, { raw: true });
             assert.equal(response, v2Response);
         });
 
@@ -65,7 +71,7 @@ describe("KustoClient", function () {
             let url = "https://cluster.kusto.windows.net";
             let client = new KustoClient(url);
             try{
-                const response = client._parseResponse({ request: { path: "/v2/query/" }, data: {} });
+                const response = client._parseResponse({}, ExecutionType.Query);
             }
             catch(ex){
                 assert.equal(ex, "Failed to parse response ({undefined}) with the following error [TypeError: data.forEach is not a function].");
@@ -74,13 +80,12 @@ describe("KustoClient", function () {
             assert.fail();
         });
 
-        
         it("erred v2 not partial", function () {
             let url = "https://cluster.kusto.windows.net";
             let client = new KustoClient(url);
 
             try{
-                const response = client._parseResponse({ request: { path: "/v2/query/" }, data: v2ResponseError });
+                const response = client._parseResponse(v2ResponseError, ExecutionType.Query);
             }
             catch(ex){
                 assert.equal(ex.startsWith("Kusto request had errors"), true);
@@ -97,7 +102,7 @@ describe("KustoClient", function () {
             let timeoutMs = moment.duration(2.51, "minutes").asMilliseconds();
             clientRequestProps.setTimeout(timeoutMs);
             client.aadHelper._getAuthHeader = () => { return "MockToken" };
-            client._doRequest = (endpoint, headers, payload, timeout, properties) => {
+            client._doRequest = (endpoint, executionType, headers, payload, timeout, properties) => {
                 let payloadObj = JSON.parse(payload);
                 assert.equal(payloadObj.properties.Options.servertimeout, "00:02:30.6");
                 assert.equal(timeout, timeoutMs + moment.duration(0.5, "minutes").asMilliseconds());
@@ -114,7 +119,7 @@ describe("KustoClient", function () {
             let timeoutMs = moment.duration(2.51, "minutes").asMilliseconds();
             clientRequestProps.setClientTimeout(timeoutMs);
             client.aadHelper._getAuthHeader = () => { return "MockToken" };
-            client._doRequest = (endpoint, headers, payload, timeout, properties) => {
+            client._doRequest = (endpoint, executionType, headers, payload, timeout, properties) => {
                 let payloadObj = JSON.parse(payload);
                 assert.equal(timeout, timeoutMs);
             };
@@ -127,7 +132,7 @@ describe("KustoClient", function () {
             let client = new KustoClient(url);
 
             client.aadHelper._getAuthHeader = () => { return "MockToken" };
-            client._doRequest = (endpoint, headers, payload, timeout, properties) => {
+            client._doRequest = (endpoint, executionType, headers, payload, timeout, properties) => {
                 assert.equal(timeout, moment.duration(4.5, "minutes").asMilliseconds());
             };
 
@@ -138,7 +143,7 @@ describe("KustoClient", function () {
             let url = "https://cluster.kusto.windows.net";
             let client = new KustoClient(url);
             client.aadHelper._getAuthHeader = () => { return "MockToken" };
-            client._doRequest = (endpoint, headers, payload, timeout, properties) => {
+            client._doRequest = (endpoint, executionType, headers, payload, timeout, properties) => {
                 assert.equal(timeout, moment.duration(10.5, "minutes").asMilliseconds());
             };
 
@@ -153,7 +158,7 @@ describe("KustoClient", function () {
             let clientRequestProps = new KustoClientRequestProperties();
             clientRequestProps.clientRequestId = clientRequestId;
             client.aadHelper._getAuthHeader = () => { return "MockToken" };
-            client._doRequest = (endpoint, headers, payload, timeout, properties) => {
+            client._doRequest = (endpoint, executionType, headers, payload, timeout, properties) => {
                 assert.equal(headers["x-ms-client-request-id"], clientRequestId);
             };
 


### PR DESCRIPTION
Parse response according to execution type instead of path, and by that - support proxy url and reduce string searches.


**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- Support proxy url
