### PR TITLE
Update client to support v1 Models on Query

### DIFF
--- a/azure-kusto-data/source/client.js
+++ b/azure-kusto-data/source/client.js
@@ -133,7 +133,11 @@ module.exports = class KustoClient {
         let kustoResponse = null;
         try {
             if (executionType == ExecutionType.Query) {
-                kustoResponse = new KustoResponseDataSetV2(response);
+                if(this.endpoints.query.includes("v1")){
+                    kustoResponse = new KustoResponseDataSetV1(response);
+                }else{
+                    kustoResponse = new KustoResponseDataSetV2(response);
+                }
             } else {
                 kustoResponse = new KustoResponseDataSetV1(response);
             }


### PR DESCRIPTION
#### Pull Request Description

The recent change that was made completely removes the ability to use v1 Query Response Models.   This change puts back the ability to use v1 Response Models if the endpoint was made against the v1 API.


---

