### PR TITLE
Separate warnings from errors

### DIFF
--- a/azure-kusto-data/package-lock.json
+++ b/azure-kusto-data/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-kusto-data",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/azure-kusto-data/package.json
+++ b/azure-kusto-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-kusto-data",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Azure Data Explorer Query SDK",
   "main": "index.js",
   "types": "index.d.ts",

--- a/azure-kusto-data/source/client.ts
+++ b/azure-kusto-data/source/client.ts
@@ -155,7 +155,7 @@ export class KustoClient {
         } catch (ex) {
             throw new Error(`Failed to parse response ({${status}}) with the following error [${ex}].`);
         }
-        if (kustoResponse.getErrorsCount() > 0) {
+        if (kustoResponse.getErrorsCount().errors > 0) {
             throw new Error(`Kusto request had errors. ${kustoResponse.getExceptions()}`);
         }
         return kustoResponse;

--- a/azure-kusto-ingest/package-lock.json
+++ b/azure-kusto-ingest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-kusto-ingest",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/azure-kusto-ingest/package.json
+++ b/azure-kusto-ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-kusto-ingest",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Azure Data Explorer Ingestion SDK",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Now warnings will not fail queries, aligning our behaviour with other sdks.
You can still access them via the new getWarnings method on your result.

Fixes #104