### PR TITLE
Fix acquireToken in managedIdentitiesClient by adding the correct headers and fix url redundant char

### DIFF
--- a/azure-kusto-data/package.json
+++ b/azure-kusto-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-kusto-data",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Azure Data Explorer Query SDK",
   "main": "index.js",
   "types": "index.d.ts",

--- a/azure-kusto-data/package.json
+++ b/azure-kusto-data/package.json
@@ -26,6 +26,7 @@
   },
   "author": "",
   "license": "ISC",
+  "homepage": "https://github.com/Azure/azure-kusto-node/blob/master/azure-kusto-data/README.md",
   "dependencies": {
     "@azure/ms-rest-nodeauth": "^3.0.3",
     "adal-node": "^0.1.28",

--- a/azure-kusto-data/source/managedIdentitiesClient.ts
+++ b/azure-kusto-data/source/managedIdentitiesClient.ts
@@ -9,13 +9,15 @@ const MSI_API_VERSION = "2018-02-01";
 const MSI_FUNCTION_API_VERSION = "2017-09-01";
 
 export default function acquireToken<T>(resource: string, msiEndpoint: string, msiClientId: string, msiSecret: string, callback: (error: string | null, token?: { tokenType: string; accessToken: string }) => T) {
-    let msiUri = `${msiEndpoint}/?resource=${resource}&api-version=${msiSecret ? MSI_FUNCTION_API_VERSION : MSI_API_VERSION}`;
+    let msiUri = `${msiEndpoint}?resource=${resource}&api-version=${msiSecret ? MSI_FUNCTION_API_VERSION : MSI_API_VERSION}`;
 
     if (msiClientId) {
         msiUri += `&client_id=${msiClientId}`;
     }
 
-    const headers: any = {};
+    const headers: any = {
+        Metadata: true
+    };
 
     if (msiSecret) {
         headers.Secret = msiSecret;


### PR DESCRIPTION
#### Pull Request Description

* MSI functionality is broken because it can't fetch the accessToken. The URL with an extra `/` couldn't be processed by the request method.
* Metadata header has been added because of this is how MSI works in Microsoft globally.

---

#### Future Release Comment

**Fixes:**
- Fix broken MSI functionality 
