### PR TITLE
Added support for custom parsers

### DIFF
--- a/azure-kusto-data/example.js
+++ b/azure-kusto-data/example.js
@@ -18,7 +18,7 @@ async function start() {
     try {
         const results = await kustoClient.execute(database, `['${table}'] | limit 1`);
         console.log(JSON.stringify(results));
-        console.log(results.primaryResults[0].toString());
+        console.log(results.primaryResults[0].toJsonString());
     }
     catch (error) {
         console.log(error);
@@ -40,7 +40,7 @@ async function start() {
     try {
         const results = await kustoClient.execute(database, `['${table}'] | limit 1`, clientRequestProps);
         console.log(JSON.stringify(results));
-        console.log(results.primaryResults[0].toString());
+        console.log(results.primaryResults[0].toJsonString());
     }
     catch (error) {
         console.log(error);

--- a/azure-kusto-data/example.js
+++ b/azure-kusto-data/example.js
@@ -18,7 +18,7 @@ async function start() {
     try {
         const results = await kustoClient.execute(database, `['${table}'] | limit 1`);
         console.log(JSON.stringify(results));
-        console.log(results.primaryResults[0].toJsonString());
+        console.log(results.primaryResults[0].toString());
     }
     catch (error) {
         console.log(error);
@@ -40,7 +40,7 @@ async function start() {
     try {
         const results = await kustoClient.execute(database, `['${table}'] | limit 1`, clientRequestProps);
         console.log(JSON.stringify(results));
-        console.log(results.primaryResults[0].toJsonString());
+        console.log(results.primaryResults[0].toString());
     }
     catch (error) {
         console.log(error);

--- a/azure-kusto-data/source/models.ts
+++ b/azure-kusto-data/source/models.ts
@@ -156,6 +156,13 @@ export class KustoResultTable {
         }
     }
 
+    /**
+     * @deprecated use the compliant toJSON() instead
+     */
+    toJson() {
+        return this.toJSON();
+    }
+
     toJSON() {
         const table: any = {};
 

--- a/azure-kusto-data/source/models.ts
+++ b/azure-kusto-data/source/models.ts
@@ -76,7 +76,7 @@ export class KustoResultRow {
         return this[this.columns[index].name as string];
     }
 
-    toObject() {
+    toJSON() {
         const obj: any = {};
 
         for (const col of this.columns) {
@@ -86,8 +86,8 @@ export class KustoResultRow {
         return obj;
     }
 
-    toJsonString() {
-        return JSON.stringify(this.toObject());
+    toString() {
+        return JSON.stringify(this.toJSON());
     }
 }
 
@@ -156,19 +156,19 @@ export class KustoResultTable {
         }
     }
 
-    toObject() {
+    toJSON() {
         const table: any = {};
 
         table.name = this.name;
         table.data = [];
         for (const row of this.rows()) {
-            table.data.push(row.toObject());
+            table.data.push(row.toJSON());
         }
 
         return table;
     }
 
-    toJsonString() {
-        return JSON.stringify(this.toObject());
+    toString() {
+        return JSON.stringify(this.toJSON());
     }
 }

--- a/azure-kusto-data/test/modelsTest.ts
+++ b/azure-kusto-data/test/modelsTest.ts
@@ -83,7 +83,7 @@ describe("KustoResultRow", function () {
             for (let index = 0; index < inputColumns.length; index++) {
                 const currentActual = asJson[inputColumns[index].name as string];
                 if (inputColumns[index].type === "timespan") {
-                    assert.strictEqual(Number(currentActual), expectedValues[index]);
+                    assert.strictEqual(Number(currentActual), Number(expectedValues[index]));
                 }
                 else if (typeof(currentActual) == "object") {
                     assert.strictEqual(currentActual.toString(), expectedValues[index].toString());

--- a/azure-kusto-data/test/modelsTest.ts
+++ b/azure-kusto-data/test/modelsTest.ts
@@ -51,7 +51,7 @@ describe("KustoResultRow", function () {
 
             const actual = new KustoResultRow(inputColumns, inputValues);
 
-            assert.equal(actual.columns.length, inputColumns.length);
+            assert.strictEqual(actual.columns.length, inputColumns.length);
         });
 
         it("column ordinal affects order", function () {
@@ -70,7 +70,7 @@ describe("KustoResultRow", function () {
                 inputValues
             );
 
-            const asJson = actual.toJson();
+            const asJson = actual.toObject();
             const expectedValues = [
                 moment(inputValues[0] as string),
                 inputValues[1],
@@ -83,12 +83,54 @@ describe("KustoResultRow", function () {
             for (let index = 0; index < inputColumns.length; index++) {
                 const currentActual = asJson[inputColumns[index].name as string];
                 if (inputColumns[index].type === "timespan") {
-                    assert.equal(Number(currentActual), expectedValues[index]);
+                    assert.strictEqual(Number(currentActual), expectedValues[index]);
                 }
                 else if (typeof(currentActual) == "object") {
-                    assert.equal(currentActual.toString(), expectedValues[index].toString());
+                    assert.strictEqual(currentActual.toString(), expectedValues[index].toString());
                 } else {
-                    assert.equal(currentActual, expectedValues[index]);
+                    assert.strictEqual(currentActual, expectedValues[index]);
+                }
+            }
+
+        });
+
+        it("custom parsers", function () {
+            const inputValues = [
+                "2016-06-06T15:35:00Z",
+                "foo",
+                101,
+                3.14,
+                false,
+                3493235670000
+            ];
+
+            const reverseOrderColumns = rawColumns.slice().reverse();
+            const actual = new KustoResultRow(
+                reverseOrderColumns.map((c, i) => new KustoResultColumn(c, rawColumns.length - i - 1)),
+                inputValues,
+                (t) => t + "-date",
+                (t) => t + 5
+            );
+
+            const asJson = actual.toObject();
+            const expectedValues = [
+                "2016-06-06T15:35:00Z-date",
+                inputValues[1],
+                inputValues[2],
+                inputValues[3],
+                inputValues[4],
+                3493235670005,
+            ];
+
+            for (let index = 0; index < inputColumns.length; index++) {
+                const currentActual = asJson[inputColumns[index].name as string];
+                if (inputColumns[index].type === "timespan") {
+                    assert.strictEqual(Number(currentActual), expectedValues[index]);
+                }
+                else if (typeof(currentActual) == "object") {
+                    assert.strictEqual(currentActual.toString(), expectedValues[index].toString());
+                } else {
+                    assert.strictEqual(currentActual, expectedValues[index]);
                 }
             }
 
@@ -106,7 +148,7 @@ describe("KustoResultRow", function () {
 
             const actual = new KustoResultRow(inputColumns, inputValues);
 
-            assert.equal(actual.columns.length, inputColumns.length);
+            assert.strictEqual(actual.columns.length, inputColumns.length);
         });
 
         it("mismatching data - less columns than data ", function () {
@@ -121,7 +163,7 @@ describe("KustoResultRow", function () {
 
             const actual = new KustoResultRow(inputColumns, inputValues);
 
-            assert.equal(actual.columns.length, inputColumns.length);
+            assert.strictEqual(actual.columns.length, inputColumns.length);
         });
 
 
@@ -137,7 +179,7 @@ describe("KustoResultRow", function () {
 
             const actual = new KustoResultRow(inputColumns, inputValues);
 
-            assert.equal(actual.columns.length, inputColumns.length);
+            assert.strictEqual(actual.columns.length, inputColumns.length);
         });
 
         it("iterate data", function () {
@@ -157,11 +199,11 @@ describe("KustoResultRow", function () {
             let i = 0;
 
             for (const v of actual.values()) {
-                assert.equal(v, inputValues[i]);
+                assert.strictEqual(v, inputValues[i]);
                 values.push(v);
                 i++;
             }
-            assert.equal(actual.columns.length, inputValues.length);
+            assert.strictEqual(actual.columns.length, inputValues.length);
         });
 
         it("mapped props", function () {
@@ -185,12 +227,12 @@ describe("KustoResultRow", function () {
 
             const actual = new KustoResultRow(inputColumns, inputValues);
 
-            assert.equal(actual.Timestamp.toString(), expectedValues[0].toString());
-            assert.equal(actual.Name, expectedValues[1]);
-            assert.equal(actual.Altitude, expectedValues[2]);
-            assert.equal(actual.Temperature, expectedValues[3]);
-            assert.equal(actual.IsFlying, expectedValues[4]);
-            assert.equal(actual.TimeFlying.toString(), expectedValues[5].toString());
+            assert.strictEqual(actual.Timestamp.toString(), expectedValues[0].toString());
+            assert.strictEqual(actual.Name, expectedValues[1]);
+            assert.strictEqual(actual.Altitude, expectedValues[2]);
+            assert.strictEqual(actual.Temperature, expectedValues[3]);
+            assert.strictEqual(actual.IsFlying, expectedValues[4]);
+            assert.strictEqual(actual.TimeFlying.toString(), expectedValues[5].toString());
         });
 
         it("value at", function () {
@@ -216,9 +258,9 @@ describe("KustoResultRow", function () {
 
             for (let i = 0; i < inputValues.length; i++) {
                 if (typeof (expectedValues[i]) == "object") {
-                    assert.equal(JSON.stringify(actual.getValueAt(i)), JSON.stringify(expectedValues[i]));
+                    assert.strictEqual(JSON.stringify(actual.getValueAt(i)), JSON.stringify(expectedValues[i]));
                 } else {
-                    assert.equal(actual.getValueAt(i), expectedValues[i]);
+                    assert.strictEqual(actual.getValueAt(i), expectedValues[i]);
                 }
             }
         });
@@ -257,15 +299,15 @@ describe("KustoResultColumn", function () {
         it("valid input", function () {
             const actual = new KustoResultColumn(rawColumns[1], 0);
 
-            assert.equal(actual.name, rawColumns[1].ColumnName);
+            assert.strictEqual(actual.name, rawColumns[1].ColumnName);
         });
 
         it("invalid input - missing props", function () {
             const actualMissingType = new KustoResultColumn(rawColumns[2], 0);
             const actualMissingName = new KustoResultColumn(rawColumns[3], 0);
 
-            assert.equal(actualMissingName.name, null);
-            assert.equal(actualMissingType.type, null);
+            assert.strictEqual(actualMissingName.name, null);
+            assert.strictEqual(actualMissingType.type, null);
         });
 
 
@@ -278,8 +320,8 @@ describe("KustoResultTable", function () {
         it("valid initialization", function () {
             const actual = new KustoResultTable(v2Response[2]);
 
-            assert.equal(actual.columns.length, 6);
-            assert.equal(actual._rows.length, 3);
+            assert.strictEqual(actual.columns.length, 6);
+            assert.strictEqual(actual._rows.length, 3);
         });
         it("iterate over rows", function () {
             const actual = new KustoResultTable(v2Response[2]);
@@ -287,12 +329,29 @@ describe("KustoResultTable", function () {
             const rows = [];
             for (const row of actual.rows()) {
                 rows.push(row);
-                assert.equal(
+                assert.strictEqual(
                     JSON.stringify(row),
                     JSON.stringify(new KustoResultRow(row.columns, row.raw)));
             }
 
-            assert.equal(rows.length, 3);
+            assert.strictEqual(rows.length, 3);
+        });
+        it("iterate over rows with custom parsers", function () {
+            const actual = new KustoResultTable(v2Response[2]);
+            const dateParser =(t: string) => t + "-date";
+            const timeParser =(t: number) => t + 5;
+            actual.dateTimeParser = dateParser;
+            actual.timeSpanParser = timeParser;
+
+            const rows = [];
+            for (const row of actual.rows()) {
+                rows.push(row);
+                assert.strictEqual(
+                    JSON.stringify(row),
+                    JSON.stringify(new KustoResultRow(row.columns, row.raw, dateParser, timeParser)));
+            }
+
+            assert.strictEqual(rows.length, 3);
         });
     });
 });

--- a/azure-kusto-data/test/modelsTest.ts
+++ b/azure-kusto-data/test/modelsTest.ts
@@ -125,7 +125,7 @@ describe("KustoResultRow", function () {
             for (let index = 0; index < inputColumns.length; index++) {
                 const currentActual = asJson[inputColumns[index].name as string];
                 if (inputColumns[index].type === "timespan") {
-                    assert.strictEqual(Number(currentActual), expectedValues[index]);
+                    assert.strictEqual(Number(currentActual), Number(expectedValues[index]));
                 }
                 else if (typeof(currentActual) == "object") {
                     assert.strictEqual(currentActual.toString(), expectedValues[index].toString());

--- a/azure-kusto-data/test/modelsTest.ts
+++ b/azure-kusto-data/test/modelsTest.ts
@@ -94,7 +94,7 @@ describe("KustoResultRow", () => {
 
         });
 
-        it("custom parsers", function () {
+        it("custom parsers", () => {
             const inputValues = [
                 "2016-06-06T15:35:00Z",
                 "foo",
@@ -127,7 +127,7 @@ describe("KustoResultRow", () => {
                 if (inputColumns[index].type === "timespan") {
                     assert.strictEqual(Number(currentActual), Number(expectedValues[index]));
                 }
-                else if (typeof(currentActual) == "object") {
+                else if (typeof(currentActual) === "object") {
                     assert.strictEqual(currentActual.toString(), expectedValues[index].toString());
                 } else {
                     assert.strictEqual(currentActual, expectedValues[index]);
@@ -336,7 +336,7 @@ describe("KustoResultTable", () => {
 
             assert.strictEqual(rows.length, 3);
         });
-        it("iterate over rows with custom parsers", function () {
+        it("iterate over rows with custom parsers", () => {
             const actual = new KustoResultTable(v2Response[2]);
             const dateParser =(t: string) => t + "-date";
             const timeParser =(t: number) => t + 5;

--- a/azure-kusto-data/test/modelsTest.ts
+++ b/azure-kusto-data/test/modelsTest.ts
@@ -70,7 +70,7 @@ describe("KustoResultRow", () => {
                 inputValues
             );
 
-            const asJson = actual.toObject();
+            const asJson = actual.toJSON();
             const expectedValues = [
                 moment(inputValues[0] as string),
                 inputValues[1],
@@ -112,7 +112,7 @@ describe("KustoResultRow", () => {
                 (t) => t + 5
             );
 
-            const asJson = actual.toObject();
+            const asJson = actual.toJSON();
             const expectedValues = [
                 "2016-06-06T15:35:00Z-date",
                 inputValues[1],


### PR DESCRIPTION
* Renamed methods to avoid confusion (if we're doing a breaking change anyway..):
   * toJson -> toObject (it wasn't a json string, it creates an object)
   * toString -> toJsonString (to make clear we're doing Stringify)
* Added support for custom parsers for date and time in rows, solves #157 

