### PR TITLE
Fixed lints and deprecated functions

### DIFF
--- a/azure-kusto-data/source/client.ts
+++ b/azure-kusto-data/source/client.ts
@@ -49,7 +49,7 @@ export class KustoClient {
         };
         this.axiosInstance = axios.create({
             headers,
-            validateStatus: (status: number) => status == 200,
+            validateStatus: (status: number) => status === 200,
 
             // keepAlive pools and reuses TCP connections, so it's faster
             httpAgent: new http.Agent({ keepAlive: true }),
@@ -172,13 +172,13 @@ export class KustoClient {
 
     _parseResponse(response: any, executionType: ExecutionType, properties?: ClientRequestProperties | null, status?: number) : KustoResponseDataSet {
         const {raw} = properties || {};
-        if (raw === true || executionType == ExecutionType.Ingest) {
+        if (raw === true || executionType === ExecutionType.Ingest) {
             return response;
         }
 
         let kustoResponse = null;
         try {
-            if (executionType == ExecutionType.Query) {
+            if (executionType === ExecutionType.Query) {
                 kustoResponse = new KustoResponseDataSetV2(response);
             } else {
                 kustoResponse = new KustoResponseDataSetV1(response);
@@ -205,7 +205,7 @@ export class KustoClient {
             }
         }
 
-        return (executionType == ExecutionType.Query ||  executionType == ExecutionType.QueryV1) ? QUERY_TIMEOUT_IN_MILLISECS : COMMAND_TIMEOUT_IN_MILLISECS;
+        return (executionType === ExecutionType.Query ||  executionType === ExecutionType.QueryV1) ? QUERY_TIMEOUT_IN_MILLISECS : COMMAND_TIMEOUT_IN_MILLISECS;
     }
 }
 

--- a/azure-kusto-data/source/cloudSettings.ts
+++ b/azure-kusto-data/source/cloudSettings.ts
@@ -45,15 +45,15 @@ export class CloudSettings {
 
         try {
             const response = await axios.get(kustoUri + this.METADATA_ENDPOINT);
-            if (response.status == 200) {
+            if (response.status === 200) {
                 this.cloudCache[kustoUri] = response.data.AzureAD || this.defaultCloudInfo;
             }
             else {
                 throw new Error(`Kusto returned an invalid cloud metadata response - ${response}`);
             }
         }
-        catch (ex: any) {
-            if (ex.response?.status == 404) {
+        catch (ex) {
+            if (axios.isAxiosError(ex) && ex.response?.status === 404) {
                 // For now as long not all proxies implement the metadata endpoint, if no endpoint exists return public cloud data
                 this.cloudCache[kustoUri] = this.defaultCloudInfo;
             }

--- a/azure-kusto-data/source/connectionBuilder.ts
+++ b/azure-kusto-data/source/connectionBuilder.ts
@@ -106,8 +106,8 @@ export class KustoConnectionStringBuilder {
     }
 
     static withAadUserPasswordAuthentication(connectionString: string, userId: string, password: string, authorityId?: string) {
-        if (!userId || userId.trim().length == 0) throw new Error("Invalid user");
-        if (!password || password.trim().length == 0) throw new Error("Invalid password");
+        if (!userId || userId.trim().length === 0) throw new Error("Invalid user");
+        if (!password || password.trim().length === 0) throw new Error("Invalid password");
 
         const kcsb = new KustoConnectionStringBuilder(connectionString);
         kcsb[KeywordMapping.aadUserId.propName] = userId;
@@ -118,8 +118,8 @@ export class KustoConnectionStringBuilder {
     }
 
     static withAadApplicationKeyAuthentication(connectionString: string, aadAppId: string, appKey: string, authorityId?: string) {
-        if (!aadAppId || aadAppId.trim().length == 0) throw new Error("Invalid app id");
-        if (!appKey || appKey.trim().length == 0) throw new Error("Invalid app key");
+        if (!aadAppId || aadAppId.trim().length === 0) throw new Error("Invalid app id");
+        if (!appKey || appKey.trim().length === 0) throw new Error("Invalid app key");
 
         const kcsb = new KustoConnectionStringBuilder(connectionString);
         kcsb[KeywordMapping.applicationClientId.propName] = aadAppId;
@@ -130,9 +130,9 @@ export class KustoConnectionStringBuilder {
     }
 
     static withAadApplicationCertificateAuthentication(connectionString: string, aadAppId: string, applicationCertificatePrivateKey: string, applicationCertificateThumbprint: string,  authorityId?: string, applicationCertificateX5c?: string) {
-        if (!aadAppId || aadAppId.trim().length == 0) throw new Error("Invalid app id");
-        if (!applicationCertificatePrivateKey || applicationCertificatePrivateKey.trim().length == 0) throw new Error("Invalid certificate");
-        if (!applicationCertificateThumbprint || applicationCertificateThumbprint.trim().length == 0) throw new Error("Invalid thumbprint");
+        if (!aadAppId || aadAppId.trim().length === 0) throw new Error("Invalid app id");
+        if (!applicationCertificatePrivateKey || applicationCertificatePrivateKey.trim().length === 0) throw new Error("Invalid certificate");
+        if (!applicationCertificateThumbprint || applicationCertificateThumbprint.trim().length === 0) throw new Error("Invalid thumbprint");
 
         const kcsb = new KustoConnectionStringBuilder(connectionString);
         kcsb[KeywordMapping.applicationClientId.propName] = aadAppId;
@@ -145,7 +145,7 @@ export class KustoConnectionStringBuilder {
     }
 
 
-    static withAadDeviceAuthentication(connectionString: string, authorityId: string, deviceCodeCallback?: (response: DeviceCodeResponse) => void) {
+    static withAadDeviceAuthentication(connectionString: string, authorityId: string = "common", deviceCodeCallback?: (response: DeviceCodeResponse) => void) {
         const kcsb = new KustoConnectionStringBuilder(connectionString);
         kcsb[KeywordMapping.authorityId.propName] = authorityId;
         kcsb.deviceCodeCallback = deviceCodeCallback;

--- a/azure-kusto-data/source/models.ts
+++ b/azure-kusto-data/source/models.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+// We want all the Kusto table models in this file
+/* tslint:disable:max-classes-per-file */
+
 import moment from "moment";
 
 export enum WellKnownDataSet {
@@ -8,7 +11,7 @@ export enum WellKnownDataSet {
     QueryCompletionInformation = "QueryCompletionInformation",
     TableOfContents = "TableOfContents",
     QueryProperties = "QueryProperties"
-};
+}
 
 const ValueParser: { [fromString: string]: (typeof moment | typeof moment.duration) } = {
     datetime: moment,

--- a/azure-kusto-data/source/response.ts
+++ b/azure-kusto-data/source/response.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+// We want all the Response models to be in this file
+/* tslint:disable:max-classes-per-file */
+
 import {KustoResultTable, Table, WellKnownDataSet} from "./models";
 
 interface V2DataSetHeaderFrame {
@@ -78,7 +81,7 @@ export abstract class KustoResponseDataSet {
         let errors = 0;
         let warnings = 0;
 
-        if (this.statusTable && this.statusTable._rows.length != 0) {
+        if (this.statusTable && this.statusTable._rows.length !== 0) {
             let minLevel = ErrorLevels.Error;
             const errorColumn = this.getErrorColumn();
             for (const row of this.statusTable.rows()) {
@@ -86,10 +89,10 @@ export abstract class KustoResponseDataSet {
                     if (row[errorColumn] < minLevel) {
                         minLevel = row[errorColumn];
                         errors = 1;
-                    } else if (row[errorColumn] == minLevel) {
+                    } else if (row[errorColumn] === minLevel) {
                         errors += 1;
                     }
-                } else if (row[errorColumn] == warnings) {
+                } else if (row[errorColumn] === warnings) {
                     warnings += 1;
                 }
             }
@@ -103,7 +106,7 @@ export abstract class KustoResponseDataSet {
 
     private getErrorsByLevel(errorLevel: ErrorLevels) {
         const result = [];
-        if (this.statusTable && this.statusTable._rows.length != 0) {
+        if (this.statusTable && this.statusTable._rows.length !== 0) {
             const errorColumn = this.getErrorColumn();
             const cridColumn = this.getCridColumn();
             const statusColumn = this.getStatusColumn();
@@ -167,7 +170,7 @@ export class KustoResponseDataSetV1 extends KustoResponseDataSet {
 
             this.tables[0].id = 0;
 
-            if (this.tables.length == 2) {
+            if (this.tables.length === 2) {
                 this.tables[1].kind = WellKnownDataSet.QueryProperties;
                 this.tables[1].id = 1;
             }
@@ -227,4 +230,4 @@ export class KustoResponseDataSetV2 extends KustoResponseDataSet {
         this.dataSetCompletion = dataSetCompletion;
         this.version = "2.0";
     }
-};
+}

--- a/azure-kusto-data/source/tokenProvider.ts
+++ b/azure-kusto-data/source/tokenProvider.ts
@@ -5,6 +5,9 @@ import { DeviceCodeResponse } from "@azure/msal-common";
 import { ManagedIdentityCredential, AzureCliCredential} from "@azure/identity";
 import { CloudSettings, CloudInfo } from "./cloudSettings"
 
+// We want all the Token Providers in this file
+/* tslint:disable:max-classes-per-file */
+
 export declare type TokenResponse = {
     tokenType: string;
     accessToken: string;
@@ -22,7 +25,7 @@ export abstract class TokenProviderBase {
 
     abstract acquireToken(): Promise<TokenResponse>;
 
-    constructor(kustoUri: string) {
+    protected constructor(kustoUri: string) {
         this.kustoUri = kustoUri;
         if (kustoUri != null) {
             const suffix = this.kustoUri.endsWith("/") ? ".default" : "/.default";
@@ -121,7 +124,7 @@ abstract class MsalTokenProvider extends TokenProviderBase {
     abstract initClient(): void;
     abstract acquireMsalToken(): Promise<AuthenticationResult | null>;
 
-    constructor(kustoUri: string, authorityId?: string) {
+    protected constructor(kustoUri: string, authorityId?: string) {
         super(kustoUri);
         this.initialized = false;
         this.authorityId = authorityId;

--- a/azure-kusto-data/test/clientTest.ts
+++ b/azure-kusto-data/test/clientTest.ts
@@ -14,14 +14,10 @@ import {
     KustoResponseDataSetV2
 } from "../source/response";
 
-// tslint:disable-next-line:no-var-requires
-const v2Response = require("./data/response/v2");
-// tslint:disable-next-line:no-var-requires
-const v2ResponseError = require("./data/response/v2error");
-// tslint:disable-next-line:no-var-requires
-const v1Response = require("./data/response/v1");
-// tslint:disable-next-line:no-var-requires variable-name
-const v1_2Response = require("./data/response/v1_2");
+import v2Response from "./data/response/v2.json";
+import v2ResponseError from "./data/response/v2error.json";
+import v1Response from "./data/response/v1.json";
+import v1_2Response from "./data/response/v1_2.json";
 
 enum ExecutionType {
     Mgmt = "mgmt",
@@ -36,8 +32,8 @@ describe("KustoClient", function () {
             const url = "https://cluster.kusto.windows.net";
             const client = new KustoClient(url);
 
-            assert.equal(client.connectionString.authorityId, "common");
-            assert.equal(client.connectionString.dataSource, url);
+            assert.strictEqual(client.connectionString.authorityId, "common");
+            assert.strictEqual(client.connectionString.dataSource, url);
         });
     });
 
@@ -47,7 +43,7 @@ describe("KustoClient", function () {
             const client = new KustoClient(url);
 
             const response = client._parseResponse(v1Response, ExecutionType.Mgmt);
-            assert.equal((response as KustoResponseDataSetV1).version, "1.0");
+            assert.strictEqual((response as KustoResponseDataSetV1).version, "1.0");
         });
 
         it("valid v1 more data", function () {
@@ -55,7 +51,7 @@ describe("KustoClient", function () {
             const client = new KustoClient(url);
 
             const response = client._parseResponse(v1_2Response, ExecutionType.QueryV1);
-            assert.equal((response as KustoResponseDataSetV1).version, "1.0");
+            assert.strictEqual((response as KustoResponseDataSetV1).version, "1.0");
         });
 
         it("valid v2", function () {
@@ -64,7 +60,7 @@ describe("KustoClient", function () {
 
 
             const response = client._parseResponse(v2Response, ExecutionType.Query);
-            assert.equal((response as KustoResponseDataSetV2).version, "2.0");
+            assert.strictEqual((response as KustoResponseDataSetV2).version, "2.0");
         });
 
         it("valid v2 raw", function () {
@@ -72,7 +68,7 @@ describe("KustoClient", function () {
             const client = new KustoClient(url);
 
             const response = client._parseResponse(v2Response, ExecutionType.Query, { raw: true } as ClientRequestProperties);
-            assert.equal(response, v2Response);
+            assert.strictEqual(response, v2Response);
         });
 
         it("malformed body", function () {
@@ -82,7 +78,9 @@ describe("KustoClient", function () {
                 client._parseResponse({}, ExecutionType.Query);
             }
             catch(ex){
-                ex.message.startsWith("Failed to parse response ({undefined}) with the following error [TypeError: data.forEach is not a function].");
+                assert( ex instanceof Error && ex.message.startsWith("Failed to parse response ({undefined}) with the following error [TypeError:" +
+                    " data.forEach is" +
+                    " not a function]."));
                 return;
             }
             assert.fail();
@@ -96,7 +94,7 @@ describe("KustoClient", function () {
                 client._parseResponse(v2ResponseError, ExecutionType.Query);
             }
             catch(ex){
-                assert.equal(ex.message.startsWith("Kusto request had errors"), true);
+                assert( ex instanceof Error && ex.message.startsWith("Kusto request had errors"));
                 return;
             }
             assert.fail();
@@ -112,8 +110,8 @@ describe("KustoClient", function () {
             client.aadHelper._getAuthHeader = () => { return Promise.resolve("MockToken") };
             client._doRequest = (_endpoint, _executionType, _headers, payload, timeout) => {
                 const payloadObj = JSON.parse(payload);
-                assert.equal(payloadObj.properties.Options.servertimeout, "00:02:30.6");
-                assert.equal(timeout, timeoutMs + moment.duration(0.5, "minutes").asMilliseconds());
+                assert.strictEqual(payloadObj.properties.Options.servertimeout, "00:02:30.6");
+                assert.strictEqual(timeout, timeoutMs + moment.duration(0.5, "minutes").asMilliseconds());
                 return Promise.resolve(new KustoResponseDataSetV2([]));
             };
 
@@ -130,7 +128,7 @@ describe("KustoClient", function () {
             client.aadHelper._getAuthHeader = () => { return Promise.resolve("MockToken") };
             client._doRequest = (_endpoint, _executionType, _headers, payload, timeout) => {
                 JSON.parse(payload);
-                assert.equal(timeout, timeoutMs);
+                assert.strictEqual(timeout, timeoutMs);
                 return Promise.resolve(new KustoResponseDataSetV2([]));
             };
 
@@ -143,7 +141,7 @@ describe("KustoClient", function () {
 
             client.aadHelper._getAuthHeader = () => { return Promise.resolve("MockToken") };
             client._doRequest = (_endpoint, _executionType, _headers, _payload, timeout) => {
-                assert.equal(timeout, moment.duration(4.5, "minutes").asMilliseconds());
+                assert.strictEqual(timeout, moment.duration(4.5, "minutes").asMilliseconds());
                 return Promise.resolve(new KustoResponseDataSetV2([]));
             };
 
@@ -155,7 +153,7 @@ describe("KustoClient", function () {
             const client = new KustoClient(url);
             client.aadHelper._getAuthHeader = () => { return Promise.resolve("MockToken") };
             client._doRequest = (_endpoint, _executionType, _headers, _payload, timeout) => {
-                assert.equal(timeout, moment.duration(10.5, "minutes").asMilliseconds());
+                assert.strictEqual(timeout, moment.duration(10.5, "minutes").asMilliseconds());
                 return Promise.resolve(new KustoResponseDataSetV2([]));
             };
 
@@ -175,9 +173,9 @@ describe("KustoClient", function () {
             clientRequestProps.user = user;
             client.aadHelper._getAuthHeader = () => { return Promise.resolve("MockToken") };
             client._doRequest = (_endpoint, _executionType, headers) => {
-                assert.equal(headers["x-ms-client-request-id"], clientRequestId);
-                assert.equal(headers["x-ms-app"], application);
-                assert.equal(headers["x-ms-user"], user);
+                assert.strictEqual(headers["x-ms-client-request-id"], clientRequestId);
+                assert.strictEqual(headers["x-ms-app"], application);
+                assert.strictEqual(headers["x-ms-user"], user);
                 return Promise.resolve(new KustoResponseDataSetV2([]));
             };
 
@@ -190,8 +188,8 @@ describe("KustoClient", function () {
 
             client.aadHelper._getAuthHeader = () => { return Promise.resolve("MockToken") };
             client._doRequest = (endpoint, executionType, _headers, _payload, _timeout, _properties) => {
-                assert.equal(endpoint, `${url}/v1/rest/query`);
-                assert.equal(executionType, ExecutionType.QueryV1);
+                assert.strictEqual(endpoint, `${url}/v1/rest/query`);
+                assert.strictEqual(executionType, ExecutionType.QueryV1);
                 return Promise.resolve(new KustoResponseDataSetV2([]));
             };
 

--- a/azure-kusto-data/test/clientTest.ts
+++ b/azure-kusto-data/test/clientTest.ts
@@ -26,9 +26,9 @@ enum ExecutionType {
     QueryV1 = "queryv1",
 }
 
-describe("KustoClient", function () {
-    describe("#constructor", function () {
-        it("valid", function () {
+describe("KustoClient", () => {
+    describe("#constructor", () => {
+        it("valid", () => {
             const url = "https://cluster.kusto.windows.net";
             const client = new KustoClient(url);
 
@@ -37,8 +37,8 @@ describe("KustoClient", function () {
         });
     });
 
-    describe("#_parseResponse()", function () {
-        it("valid v1", function () {
+    describe("#_parseResponse()", () => {
+        it("valid v1", () => {
             const url = "https://cluster.kusto.windows.net";
             const client = new KustoClient(url);
 
@@ -46,7 +46,7 @@ describe("KustoClient", function () {
             assert.strictEqual((response as KustoResponseDataSetV1).version, "1.0");
         });
 
-        it("valid v1 more data", function () {
+        it("valid v1 more data", () => {
             const url = "https://cluster.kusto.windows.net";
             const client = new KustoClient(url);
 
@@ -54,7 +54,7 @@ describe("KustoClient", function () {
             assert.strictEqual((response as KustoResponseDataSetV1).version, "1.0");
         });
 
-        it("valid v2", function () {
+        it("valid v2", () => {
             const url = "https://cluster.kusto.windows.net";
             const client = new KustoClient(url);
 
@@ -63,7 +63,7 @@ describe("KustoClient", function () {
             assert.strictEqual((response as KustoResponseDataSetV2).version, "2.0");
         });
 
-        it("valid v2 raw", function () {
+        it("valid v2 raw", () => {
             const url = "https://cluster.kusto.windows.net";
             const client = new KustoClient(url);
 
@@ -71,7 +71,7 @@ describe("KustoClient", function () {
             assert.strictEqual(response, v2Response);
         });
 
-        it("malformed body", function () {
+        it("malformed body", () => {
             const url = "https://cluster.kusto.windows.net";
             const client = new KustoClient(url);
             try{
@@ -86,7 +86,7 @@ describe("KustoClient", function () {
             assert.fail();
         });
 
-        it("erred v2 not partial", function () {
+        it("erred v2 not partial", () => {
             const url = "https://cluster.kusto.windows.net";
             const client = new KustoClient(url);
 
@@ -100,7 +100,7 @@ describe("KustoClient", function () {
             assert.fail();
         });
 
-        it("setTimout for request", async function () {
+        it("setTimout for request", async () => {
             const url = "https://cluster.kusto.windows.net";
             const client = new KustoClient(url);
 
@@ -118,7 +118,7 @@ describe("KustoClient", function () {
             await client.execute("Database", "Table | count", clientRequestProps);
         });
 
-        it("setClientTimout for request", async function () {
+        it("setClientTimout for request", async () => {
             const url = "https://cluster.kusto.windows.net";
             const client = new KustoClient(url);
 
@@ -135,7 +135,7 @@ describe("KustoClient", function () {
             await client.execute("Database", "Table | count", clientRequestProps);
         });
 
-        it("default timeout for query", async function () {
+        it("default timeout for query", async () => {
             const url = "https://cluster.kusto.windows.net";
             const client = new KustoClient(url);
 
@@ -148,7 +148,7 @@ describe("KustoClient", function () {
             await client.execute("Database", "Table | count");
         });
 
-        it("default timeout for admin", async function () {
+        it("default timeout for admin", async () => {
             const url = "https://cluster.kusto.windows.net";
             const client = new KustoClient(url);
             client.aadHelper._getAuthHeader = () => { return Promise.resolve("MockToken") };
@@ -160,7 +160,7 @@ describe("KustoClient", function () {
             await client.execute("Database", ".show database DataBase schema");
         });
 
-        it("set clientRequestId for request", async function () {
+        it("set clientRequestId for request", async () => {
             const url = "https://cluster.kusto.windows.net";
             const client = new KustoClient(url);
             const clientRequestId = `MyApp.MyActivity;${uuidv4()}`;
@@ -182,7 +182,7 @@ describe("KustoClient", function () {
             await client.execute("Database", "Table | count", clientRequestProps);
         });
 
-        it("executeQueryV1", async function () {
+        it("executeQueryV1", async () => {
             const url = "https://cluster.kusto.windows.net";
             const client = new KustoClient(url);
 

--- a/azure-kusto-data/test/connectionBuilderTest.ts
+++ b/azure-kusto-data/test/connectionBuilderTest.ts
@@ -5,9 +5,9 @@ import assert from "assert";
 import { v4 as uuidv4 } from 'uuid';
 import {KustoConnectionStringBuilder} from "../source/connectionBuilder";
 
-describe("KustoConnectionStringBuilder", function () {
-    describe("#constructor(connectionString)", function () {
-        it("from string with no creds", function () {
+describe("KustoConnectionStringBuilder", () => {
+    describe("#constructor(connectionString)", () => {
+        it("from string with no creds", () => {
             const kcsbs = [
                 new KustoConnectionStringBuilder("localhost"),
                 new KustoConnectionStringBuilder("data Source=localhost"),
@@ -26,7 +26,7 @@ describe("KustoConnectionStringBuilder", function () {
             }
         });
 
-        it("from string with username auth", function () {
+        it("from string with username auth", () => {
             const expectedUser = "test";
             const expectedPassword = "Pa$$w0rd";
             const kcsbs = [
@@ -53,7 +53,7 @@ describe("KustoConnectionStringBuilder", function () {
             }
         });
 
-        it("from string with app auth", function () {
+        it("from string with app auth", () => {
 
             const uuid = uuidv4();
             const key = "key of application";

--- a/azure-kusto-data/test/connectionBuilderTest.ts
+++ b/azure-kusto-data/test/connectionBuilderTest.ts
@@ -17,11 +17,11 @@ describe("KustoConnectionStringBuilder", function () {
             ];
 
             for (const kcsb of kcsbs) {
-                assert.equal(kcsb.dataSource, "localhost");
-                assert.equal(kcsb.authorityId, "common");
+                assert.strictEqual(kcsb.dataSource, "localhost");
+                assert.strictEqual(kcsb.authorityId, "common");
                 const emptyFields = ["aadUserId", "password", "applicationClientId", "applicationKey"];
                 for (const field of emptyFields) {
-                    assert.equal(kcsb[field], null);
+                    assert.strictEqual(kcsb[field], undefined);
                 }
             }
         });
@@ -42,13 +42,13 @@ describe("KustoConnectionStringBuilder", function () {
             kcsbs.push(kcsb1);
 
             for (const kcsb of kcsbs) {
-                assert.equal(kcsb.dataSource, "localhost");
-                assert.equal(kcsb.aadUserId, expectedUser);
-                assert.equal(kcsb.password, expectedPassword);
-                assert.equal(kcsb.authorityId, "common");
+                assert.strictEqual(kcsb.dataSource, "localhost");
+                assert.strictEqual(kcsb.aadUserId, expectedUser);
+                assert.strictEqual(kcsb.password, expectedPassword);
+                assert.strictEqual(kcsb.authorityId, "common");
                 const emptyFields = ["applicationClientId", "applicationKey"];
                 for (const field of emptyFields) {
-                    assert.equal(kcsb[field], null);
+                    assert.strictEqual(kcsb[field], undefined);
                 }
             }
         });
@@ -72,13 +72,13 @@ describe("KustoConnectionStringBuilder", function () {
             kcsbs.push(kcsb1);
 
             for (const kcsb of kcsbs) {
-                assert.equal(kcsb.dataSource, "localhost");
-                assert.equal(kcsb.applicationClientId, uuid);
-                assert.equal(kcsb.applicationKey, key);
-                assert.equal(kcsb.authorityId, "common");
+                assert.strictEqual(kcsb.dataSource, "localhost");
+                assert.strictEqual(kcsb.applicationClientId, uuid);
+                assert.strictEqual(kcsb.applicationKey, key);
+                assert.strictEqual(kcsb.authorityId, "common");
                 const emptyFields = ["aadUserId", "password"];
                 for (const field of emptyFields) {
-                    assert.equal(kcsb[field], null);
+                    assert.strictEqual(kcsb[field], undefined);
                 }
             }
         });

--- a/azure-kusto-data/test/modelsTest.ts
+++ b/azure-kusto-data/test/modelsTest.ts
@@ -8,8 +8,8 @@ import {KustoResultColumn, KustoResultRow, KustoResultTable} from "../source/mod
 // tslint:disable-next-line:no-var-requires
 const v2Response = require("./data/response/v2.json");
 
-describe("KustoResultRow", function () {
-    describe("#constructor()", function () {
+describe("KustoResultRow", () => {
+    describe("#constructor()", () => {
         const rawColumns = [
             {
                 "ColumnName": "Timestamp",
@@ -39,7 +39,7 @@ describe("KustoResultRow", function () {
 
         const inputColumns = rawColumns.map((c, i) => new KustoResultColumn(c, i));
 
-        it("initialize properly", function () {
+        it("initialize properly", () => {
             const inputValues = [
                 "2016-06-06T15:35:00Z",
                 "foo",
@@ -54,7 +54,7 @@ describe("KustoResultRow", function () {
             assert.strictEqual(actual.columns.length, inputColumns.length);
         });
 
-        it("column ordinal affects order", function () {
+        it("column ordinal affects order", () => {
             const inputValues = [
                 "2016-06-06T15:35:00Z",
                 "foo",
@@ -85,7 +85,7 @@ describe("KustoResultRow", function () {
                 if (inputColumns[index].type === "timespan") {
                     assert.strictEqual(Number(currentActual), Number(expectedValues[index]));
                 }
-                else if (typeof(currentActual) == "object") {
+                else if (typeof(currentActual) === "object") {
                     assert.strictEqual(currentActual.toString(), expectedValues[index].toString());
                 } else {
                     assert.strictEqual(currentActual, expectedValues[index]);
@@ -94,7 +94,7 @@ describe("KustoResultRow", function () {
 
         });
 
-        it("mismatching data - less data than columns", function () {
+        it("mismatching data - less data than columns", () => {
             const inputValues = [
                 "2016-06-06T15:35:00Z",
                 "foo",
@@ -109,7 +109,7 @@ describe("KustoResultRow", function () {
             assert.strictEqual(actual.columns.length, inputColumns.length);
         });
 
-        it("mismatching data - less columns than data ", function () {
+        it("mismatching data - less columns than data ", () => {
             const inputValues = [
                 "2016-06-06T15:35:00Z",
                 "foo",
@@ -125,7 +125,7 @@ describe("KustoResultRow", function () {
         });
 
 
-        it("mismatching data - type mismatch ", function () {
+        it("mismatching data - type mismatch ", () => {
             const inputValues = [
                 "2016-06-06T15:35:00Z",
                 "foo",
@@ -140,7 +140,7 @@ describe("KustoResultRow", function () {
             assert.strictEqual(actual.columns.length, inputColumns.length);
         });
 
-        it("iterate data", function () {
+        it("iterate data", () => {
             const inputValues = [
                 "2016-06-06T15:35:00Z",
                 "foo",
@@ -164,7 +164,7 @@ describe("KustoResultRow", function () {
             assert.strictEqual(actual.columns.length, inputValues.length);
         });
 
-        it("mapped props", function () {
+        it("mapped props", () => {
             const inputValues = [
                 "2016-06-06T15:35:00Z",
                 "foo",
@@ -193,7 +193,7 @@ describe("KustoResultRow", function () {
             assert.strictEqual(actual.TimeFlying.toString(), expectedValues[5].toString());
         });
 
-        it("value at", function () {
+        it("value at", () => {
             const inputValues = [
                 "2016-06-06T15:35:00Z",
                 "foo",
@@ -215,7 +215,7 @@ describe("KustoResultRow", function () {
             const actual = new KustoResultRow(inputColumns, inputValues);
 
             for (let i = 0; i < inputValues.length; i++) {
-                if (typeof (expectedValues[i]) == "object") {
+                if (typeof (expectedValues[i]) === "object") {
                     assert.strictEqual(JSON.stringify(actual.getValueAt(i)), JSON.stringify(expectedValues[i]));
                 } else {
                     assert.strictEqual(actual.getValueAt(i), expectedValues[i]);
@@ -227,8 +227,8 @@ describe("KustoResultRow", function () {
 });
 
 
-describe("KustoResultColumn", function () {
-    describe("#constructor()", function () {
+describe("KustoResultColumn", () => {
+    describe("#constructor()", () => {
         const rawColumns = [
             {
                 "ColumnName": "Timestamp",
@@ -254,13 +254,13 @@ describe("KustoResultColumn", function () {
             }
         ];
 
-        it("valid input", function () {
+        it("valid input", () => {
             const actual = new KustoResultColumn(rawColumns[1], 0);
 
             assert.strictEqual(actual.name, rawColumns[1].ColumnName);
         });
 
-        it("invalid input - missing props", function () {
+        it("invalid input - missing props", () => {
             const actualMissingType = new KustoResultColumn(rawColumns[2], 0);
             const actualMissingName = new KustoResultColumn(rawColumns[3], 0);
 
@@ -273,15 +273,15 @@ describe("KustoResultColumn", function () {
 });
 
 
-describe("KustoResultTable", function () {
-    describe("#constructor()", function () {
-        it("valid initialization", function () {
+describe("KustoResultTable", () => {
+    describe("#constructor()", () => {
+        it("valid initialization", () => {
             const actual = new KustoResultTable(v2Response[2]);
 
             assert.strictEqual(actual.columns.length, 6);
             assert.strictEqual(actual._rows.length, 3);
         });
-        it("iterate over rows", function () {
+        it("iterate over rows", () => {
             const actual = new KustoResultTable(v2Response[2]);
 
             const rows = [];

--- a/azure-kusto-data/test/modelsTest.ts
+++ b/azure-kusto-data/test/modelsTest.ts
@@ -51,7 +51,7 @@ describe("KustoResultRow", function () {
 
             const actual = new KustoResultRow(inputColumns, inputValues);
 
-            assert.equal(actual.columns.length, inputColumns.length);
+            assert.strictEqual(actual.columns.length, inputColumns.length);
         });
 
         it("column ordinal affects order", function () {
@@ -83,12 +83,12 @@ describe("KustoResultRow", function () {
             for (let index = 0; index < inputColumns.length; index++) {
                 const currentActual = asJson[inputColumns[index].name as string];
                 if (inputColumns[index].type === "timespan") {
-                    assert.equal(Number(currentActual), expectedValues[index]);
+                    assert.strictEqual(Number(currentActual), Number(expectedValues[index]));
                 }
                 else if (typeof(currentActual) == "object") {
-                    assert.equal(currentActual.toString(), expectedValues[index].toString());
+                    assert.strictEqual(currentActual.toString(), expectedValues[index].toString());
                 } else {
-                    assert.equal(currentActual, expectedValues[index]);
+                    assert.strictEqual(currentActual, expectedValues[index]);
                 }
             }
 
@@ -106,7 +106,7 @@ describe("KustoResultRow", function () {
 
             const actual = new KustoResultRow(inputColumns, inputValues);
 
-            assert.equal(actual.columns.length, inputColumns.length);
+            assert.strictEqual(actual.columns.length, inputColumns.length);
         });
 
         it("mismatching data - less columns than data ", function () {
@@ -121,7 +121,7 @@ describe("KustoResultRow", function () {
 
             const actual = new KustoResultRow(inputColumns, inputValues);
 
-            assert.equal(actual.columns.length, inputColumns.length);
+            assert.strictEqual(actual.columns.length, inputColumns.length);
         });
 
 
@@ -137,7 +137,7 @@ describe("KustoResultRow", function () {
 
             const actual = new KustoResultRow(inputColumns, inputValues);
 
-            assert.equal(actual.columns.length, inputColumns.length);
+            assert.strictEqual(actual.columns.length, inputColumns.length);
         });
 
         it("iterate data", function () {
@@ -157,11 +157,11 @@ describe("KustoResultRow", function () {
             let i = 0;
 
             for (const v of actual.values()) {
-                assert.equal(v, inputValues[i]);
+                assert.strictEqual(v, inputValues[i]);
                 values.push(v);
                 i++;
             }
-            assert.equal(actual.columns.length, inputValues.length);
+            assert.strictEqual(actual.columns.length, inputValues.length);
         });
 
         it("mapped props", function () {
@@ -185,12 +185,12 @@ describe("KustoResultRow", function () {
 
             const actual = new KustoResultRow(inputColumns, inputValues);
 
-            assert.equal(actual.Timestamp.toString(), expectedValues[0].toString());
-            assert.equal(actual.Name, expectedValues[1]);
-            assert.equal(actual.Altitude, expectedValues[2]);
-            assert.equal(actual.Temperature, expectedValues[3]);
-            assert.equal(actual.IsFlying, expectedValues[4]);
-            assert.equal(actual.TimeFlying.toString(), expectedValues[5].toString());
+            assert.strictEqual(actual.Timestamp.toString(), expectedValues[0].toString());
+            assert.strictEqual(actual.Name, expectedValues[1]);
+            assert.strictEqual(actual.Altitude, expectedValues[2]);
+            assert.strictEqual(actual.Temperature, expectedValues[3]);
+            assert.strictEqual(actual.IsFlying, expectedValues[4]);
+            assert.strictEqual(actual.TimeFlying.toString(), expectedValues[5].toString());
         });
 
         it("value at", function () {
@@ -216,9 +216,9 @@ describe("KustoResultRow", function () {
 
             for (let i = 0; i < inputValues.length; i++) {
                 if (typeof (expectedValues[i]) == "object") {
-                    assert.equal(JSON.stringify(actual.getValueAt(i)), JSON.stringify(expectedValues[i]));
+                    assert.strictEqual(JSON.stringify(actual.getValueAt(i)), JSON.stringify(expectedValues[i]));
                 } else {
-                    assert.equal(actual.getValueAt(i), expectedValues[i]);
+                    assert.strictEqual(actual.getValueAt(i), expectedValues[i]);
                 }
             }
         });
@@ -257,15 +257,15 @@ describe("KustoResultColumn", function () {
         it("valid input", function () {
             const actual = new KustoResultColumn(rawColumns[1], 0);
 
-            assert.equal(actual.name, rawColumns[1].ColumnName);
+            assert.strictEqual(actual.name, rawColumns[1].ColumnName);
         });
 
         it("invalid input - missing props", function () {
             const actualMissingType = new KustoResultColumn(rawColumns[2], 0);
             const actualMissingName = new KustoResultColumn(rawColumns[3], 0);
 
-            assert.equal(actualMissingName.name, null);
-            assert.equal(actualMissingType.type, null);
+            assert.strictEqual(actualMissingName.name, null);
+            assert.strictEqual(actualMissingType.type, null);
         });
 
 
@@ -278,8 +278,8 @@ describe("KustoResultTable", function () {
         it("valid initialization", function () {
             const actual = new KustoResultTable(v2Response[2]);
 
-            assert.equal(actual.columns.length, 6);
-            assert.equal(actual._rows.length, 3);
+            assert.strictEqual(actual.columns.length, 6);
+            assert.strictEqual(actual._rows.length, 3);
         });
         it("iterate over rows", function () {
             const actual = new KustoResultTable(v2Response[2]);
@@ -287,12 +287,12 @@ describe("KustoResultTable", function () {
             const rows = [];
             for (const row of actual.rows()) {
                 rows.push(row);
-                assert.equal(
+                assert.strictEqual(
                     JSON.stringify(row),
                     JSON.stringify(new KustoResultRow(row.columns, row.raw)));
             }
 
-            assert.equal(rows.length, 3);
+            assert.strictEqual(rows.length, 3);
         });
     });
 });

--- a/azure-kusto-data/test/responseTest.ts
+++ b/azure-kusto-data/test/responseTest.ts
@@ -1,17 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-const assert = require("assert");
-const v2Response = require("./data/response/v2");
-const { KustoResponseDataSetV2 } = require("../source/response");
+import assert from "assert";
+
+import v2Response from "./data/response/v2.json";
+import { KustoResponseDataSetV2 } from "../source/response";
+
 
 describe("KustoResultDataSet", function () {
     describe("#constructor()", function () {
         it("valid input", function () {
-            let actual = new KustoResponseDataSetV2(v2Response);
+            // @ts-ignore - it can't infer the type from the json, but it's valid
+            const actual = new KustoResponseDataSetV2(v2Response);
 
-            assert.equal(actual.primaryResults.length, 1);
-            assert.equal(actual.tables.length, 3);
+            assert.strictEqual(actual.primaryResults.length, 1);
+            assert.strictEqual(actual.tables.length, 3);
             assert.notEqual(actual.statusTable, null);
         });
     });

--- a/azure-kusto-data/test/responseTest.ts
+++ b/azure-kusto-data/test/responseTest.ts
@@ -7,15 +7,15 @@ import v2Response from "./data/response/v2.json";
 import { KustoResponseDataSetV2 } from "../source/response";
 
 
-describe("KustoResultDataSet", function () {
-    describe("#constructor()", function () {
-        it("valid input", function () {
+describe("KustoResultDataSet", () => {
+    describe("#constructor()", () => {
+        it("valid input", () => {
             // @ts-ignore - it can't infer the type from the json, but it's valid
             const actual = new KustoResponseDataSetV2(v2Response);
 
             assert.strictEqual(actual.primaryResults.length, 1);
             assert.strictEqual(actual.tables.length, 3);
-            assert.notEqual(actual.statusTable, null);
+            assert.notStrictEqual(actual.statusTable, null);
         });
     });
 });

--- a/azure-kusto-data/test/tokenProviderTest.ts
+++ b/azure-kusto-data/test/tokenProviderTest.ts
@@ -5,9 +5,9 @@ import { CloudSettings } from "../source/cloudSettings";
 import { UserPassTokenProvider } from "../source/tokenProvider"
 import assert from "assert";
 
-describe("CloudInfo", function () {
-    describe("#CloudInfo", function () {
-        it("mfa off", async function () {
+describe("CloudInfo", () => {
+    describe("#CloudInfo", () => {
+        it("mfa off", async () => {
             const fakeUri = "https://fakeurl_mfa.kusto.windows.net"
             CloudSettings.getInstance().cloudCache[fakeUri] = {
                 LoginEndpoint: process.env.AadAuthorityUri || "https://login.microsoftonline.com",
@@ -29,7 +29,7 @@ describe("CloudInfo", function () {
             assert.strictEqual(provider.scopes[0], "https://fakeurl.kusto.windows.net/.default");
         });
 
-        it("mfa off", async function () {
+        it("mfa off", async () => {
             const fakeUri2 = "https://fakeurl2.kusto.windows.net"
             CloudSettings.getInstance().cloudCache[fakeUri2] = {
                 LoginEndpoint: process.env.AadAuthorityUri || "https://login.microsoftonline.com",

--- a/azure-kusto-data/test/tokenProviderTest.ts
+++ b/azure-kusto-data/test/tokenProviderTest.ts
@@ -9,46 +9,46 @@ describe("CloudInfo", function () {
     describe("#CloudInfo", function () {
         it("mfa off", async function () {
             const fakeUri = "https://fakeurl_mfa.kusto.windows.net"
-            const cloudInfo =
-            {
+            CloudSettings.getInstance().cloudCache[fakeUri] = {
                 LoginEndpoint: process.env.AadAuthorityUri || "https://login.microsoftonline.com",
                 LoginMfaRequired: false,
                 KustoClientAppId: "1234",
                 KustoClientRedirectUri: "https://microsoft/kustoclient",
                 KustoServiceResourceId: "https://fakeurl.kusto.windows.net",
                 FirstPartyAuthorityUrl: "https://login.microsoftonline.com/8cdef31-a31e-4b4a-93e4-5f571e91255a",
-            }
-            CloudSettings.getInstance().cloudCache[fakeUri] = cloudInfo;
+            };
 
             const provider = new UserPassTokenProvider(fakeUri, "auth_test", "a", "b")
             try {
                 await provider.acquireToken();
             }
-            catch { }// We should fail to aquire token but we want to validate the CloudSettings which acquireToken init
+            catch {
+                // We should fail to acquire token but we want to validate the CloudSettings which acquireToken init
+            }
 
-            assert.equal(provider.scopes[0], "https://fakeurl.kusto.windows.net/.default");
+            assert.strictEqual(provider.scopes[0], "https://fakeurl.kusto.windows.net/.default");
         });
 
         it("mfa off", async function () {
             const fakeUri2 = "https://fakeurl2.kusto.windows.net"
-            const cloudInfo =
-            {
+            CloudSettings.getInstance().cloudCache[fakeUri2] = {
                 LoginEndpoint: process.env.AadAuthorityUri || "https://login.microsoftonline.com",
                 LoginMfaRequired: true,
                 KustoClientAppId: "1234",
                 KustoClientRedirectUri: "https://microsoft/kustoclient",
                 KustoServiceResourceId: "https://fakeurl.kusto.windows.net",
                 FirstPartyAuthorityUrl: "https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a",
-            }
-            CloudSettings.getInstance().cloudCache[fakeUri2] = cloudInfo;
+            };
 
             const provider = new UserPassTokenProvider(fakeUri2, "auth_test", "a", "b")
             try {
                 await provider.acquireToken();
             }
-            catch { }// We should fail to aquire token but we want to validate the CloudSettings which acquireToken init
+            catch {
+                // We should fail to acquire token but we want to validate the CloudSettings which acquireToken init
+            }
 
-            assert.equal(provider.scopes[0], "https://fakeurl.kustomfa.windows.net/.default");
+            assert.strictEqual(provider.scopes[0], "https://fakeurl.kustomfa.windows.net/.default");
         });
     });
 });

--- a/azure-kusto-data/tslint.json
+++ b/azure-kusto-data/tslint.json
@@ -10,9 +10,6 @@
       "only-arrow-functions": false
     },
     "linterOptions": {
-      "exclude": [
-        "./test/**/*"
-      ]
     },
     "rulesDirectory": []
 }

--- a/azure-kusto-data/tslint.json
+++ b/azure-kusto-data/tslint.json
@@ -4,11 +4,7 @@
         "tslint:recommended"
     ],
     "jsRules": {},
-    "rules": {
-      "max-classes-per-file": false,
-      "triple-equals": false,
-      "only-arrow-functions": false
-    },
+    "rules": {},
     "linterOptions": {
     },
     "rulesDirectory": []

--- a/azure-kusto-ingest/example.js
+++ b/azure-kusto-ingest/example.js
@@ -117,7 +117,7 @@ async function startStreamingIngestion() {
     // Ingest from stream with either ReadStream or StreamDescriptor
     let stream = fs.createReadStream("file.json");
     try {
-        await streamingIngestClient.ingestFromStream("file.json", props2);
+        await streamingIngestClient.ingestFromStream(stream, props2);
         console.log("Ingestion done");
     }
     catch (err) {

--- a/azure-kusto-ingest/source/abstractKustoClient.ts
+++ b/azure-kusto-ingest/source/abstractKustoClient.ts
@@ -8,12 +8,12 @@ export abstract class AbstractKustoClient {
 
     _mergeProps(newProperties?: IngestionProperties | null): IngestionProperties {
         // no default props
-        if (newProperties == null || Object.keys(newProperties).length == 0) {
+        if (!newProperties || Object.keys(newProperties).length === 0) {
             return this.defaultProps || new IngestionProperties({});
         }
 
         // no new props
-        if (this.defaultProps == null || Object.keys(this.defaultProps).length == 0) {
+        if (this.defaultProps == null || Object.keys(this.defaultProps).length === 0) {
             return newProperties || new IngestionProperties({});
         }
         // both exist - merge

--- a/azure-kusto-ingest/source/descriptors.ts
+++ b/azure-kusto-ingest/source/descriptors.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+// We want all the Descriptors to be in this file
+/* tslint:disable:max-classes-per-file */
+
 import { v4 as uuidv4 } from 'uuid';
 import uuidValidate from "uuid-validate";
 import zlib from "zlib";
@@ -49,7 +52,7 @@ export class FileDescriptor {
                 .on("error", (err) => {
                     reject(err);
                 });
-            output.once("close", function () {
+            output.once("close", () => {
                 resolve(null);
             });
         });

--- a/azure-kusto-ingest/source/ingestionProperties.ts
+++ b/azure-kusto-ingest/source/ingestionProperties.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+// TODO: split this file when we merge the new ColumnMappings
+/* tslint:disable:max-classes-per-file */
+
 export enum DataFormat {
     CSV = "csv",
     TSV = "tsv",

--- a/azure-kusto-ingest/source/resourceManager.ts
+++ b/azure-kusto-ingest/source/resourceManager.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+// We want all the Resources related classes in this file
+/* tslint:disable:max-classes-per-file */
+
 import {Client} from "azure-kusto-data";
 import moment from "moment";
 
@@ -19,10 +22,10 @@ export class ResourceURI {
     }
 
     getSASConnectionString(): string {
-        if (this.objectType == "queue") {
+        if (this.objectType === "queue") {
             return `QueueEndpoint=https://${this.storageAccountName}.queue.core.windows.net/;SharedAccessSignature=${this.sas}`;
         }
-        if (this.objectType == "blob") {
+        if (this.objectType === "blob") {
             return `BlobEndpoint=https://${this.storageAccountName}.blob.core.windows.net/;SharedAccessSignature=${this.sas}`;
         }
 
@@ -95,7 +98,7 @@ export class ResourceManager {
     getResourceByName(table: { rows: () => any; }, resourceName: string): ResourceURI[] {
         const result = [];
         for (const row of table.rows()) {
-            if (row.ResourceTypeName == resourceName) {
+            if (row.ResourceTypeName === resourceName) {
                 result.push(ResourceURI.fromURI(row.StorageRoot));
             }
         }

--- a/azure-kusto-ingest/source/status.ts
+++ b/azure-kusto-ingest/source/status.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+// We want all the Status related classes in this file
+/* tslint:disable:max-classes-per-file */
+
 import {StatusQueue} from "./statusQ";
 import KustoIngestClient from "./ingestClient";
 import {ResourceURI} from "./resourceManager";

--- a/azure-kusto-ingest/source/statusQ.ts
+++ b/azure-kusto-ingest/source/statusQ.ts
@@ -5,6 +5,9 @@ import {PeekedMessageItem, QueueClient} from "@azure/storage-queue";
 import {ResourceURI} from "./resourceManager"
 import {StatusMessage} from "./status";
 
+// QueueDetails is a very small class, so we don't need it in a different file
+/* tslint:disable:max-classes-per-file */
+
 class QueueDetails {
     constructor(readonly name: string, readonly service: QueueClient) {
     }
@@ -38,7 +41,7 @@ export class StatusQueue {
     }
 
     _getQServices(queuesDetails: ResourceURI[]) {
-        return queuesDetails.map(function (q) {
+        return queuesDetails.map(q => {
             const sasConnectionString = q.getSASConnectionString();
             if (!sasConnectionString) {
                 throw new Error("Empty or null connection string");
@@ -77,7 +80,7 @@ export class StatusQueue {
                 if (m && Object.keys(m).length > 0) {
                     result.push(options && options.raw ? m : this.deserializeMessage(m));
 
-                    if (result.length == n) {
+                    if (result.length === n) {
                         return {done: true, nonEmptyQs, result};
                     }
                 }
@@ -116,9 +119,9 @@ export class StatusQueue {
                     result.push(options && options.raw ? m : this.deserializeMessage(m));
 
                     if (!(options && !options.remove)) {
-                        q.service.deleteMessage(m.messageId, m.popReceipt);
+                        await q.service.deleteMessage(m.messageId, m.popReceipt);
                     }
-                    if (result.length == n) {
+                    if (result.length === n) {
                         return {done: true, nonEmptyQs, result};
                     }
                 }

--- a/azure-kusto-ingest/source/streamingIngestClient.ts
+++ b/azure-kusto-ingest/source/streamingIngestClient.ts
@@ -26,7 +26,7 @@ class KustoStreamingIngestClient extends AbstractKustoClient {
         const descriptor: StreamDescriptor = stream instanceof StreamDescriptor ? stream : new StreamDescriptor(stream);
 
         const compressedStream =
-            descriptor.compressionType == CompressionType.None ? descriptor.stream.pipe(zlib.createGzip()) : descriptor.stream;
+            descriptor.compressionType === CompressionType.None ? descriptor.stream.pipe(zlib.createGzip()) : descriptor.stream;
         return this.kustoClient.executeStreamingIngest(
             props.database as string,
             props.table as string,

--- a/azure-kusto-ingest/test/descriptorsTest.ts
+++ b/azure-kusto-ingest/test/descriptorsTest.ts
@@ -4,9 +4,9 @@
 import assert from "assert";
 import {FileDescriptor} from "../source/descriptors";
 
-describe("FileDescriptor", function () {
-    describe("#constructor()", function () {
-        it("valid input zipped", function () {
+describe("FileDescriptor", () => {
+    describe("#constructor()", () => {
+        it("valid input zipped", () => {
             const desc = new FileDescriptor("./data/events.json.gz");
 
             assert.strictEqual(desc.name, "events.json.gz");
@@ -15,7 +15,7 @@ describe("FileDescriptor", function () {
 
         });
 
-        it("valid input json", function () {
+        it("valid input json", () => {
             const desc = new FileDescriptor("./data/events.json");
 
             assert.strictEqual(desc.name, "events.json");

--- a/azure-kusto-ingest/test/e2eTests/e2eTest.ts
+++ b/azure-kusto-ingest/test/e2eTests/e2eTest.ts
@@ -82,8 +82,8 @@ function main(): void {
 
     let currentCount = 0;
 
-    describe(`E2E Tests`, function () {
-        after(async function () {
+    describe(`E2E Tests`, () => {
+        after(async () => {
             try {
                 await queryClient.execute(databaseName, `.drop table ${tableName} ifexists`);
             } catch (err) {
@@ -91,7 +91,7 @@ function main(): void {
             }
         });
 
-        before('SetUp', async function () {
+        before('SetUp', async () => {
             console.log(`Create Table ${tableName}`)
             try {
                 await queryClient.execute(databaseName, `.create table ${tableName} ${tableColumns}`);
@@ -108,20 +108,20 @@ function main(): void {
             }
         });
 
-        describe('cloud info', function () {
-            it('Cached cloud info', async function () {
+        describe('cloud info', () => {
+            it('Cached cloud info', async () => {
                 const cloudInfo = CloudSettings.getInstance().cloudCache[process.env.ENGINE_CONNECTION_STRING as string]; // it should be already in the cache at this point
                 assert.strictEqual(cloudInfo.KustoClientAppId, CloudSettings.getInstance().defaultCloudInfo.KustoClientAppId);
             })
 
-            it('cloud info 404', async function () {
+            it('cloud info 404', async () => {
                 const cloudInfo = await CloudSettings.getInstance().getCloudInfoForCluster("https://www.microsoft.com");
                 assert.strictEqual(cloudInfo, CloudSettings.getInstance().defaultCloudInfo);
             })
         });
 
-        describe('ingestClient', function () {
-            it('ingestFromFile', async function () {
+        describe('ingestClient', () => {
+            it('ingestFromFile', async () => {
                 for (const item of testItems) {
                     try {
                         await ingestClient.ingestFromFile(item.path, item.ingestionProperties);
@@ -133,7 +133,7 @@ function main(): void {
                 }
             }).timeout(240000);
 
-            it('ingestFromStream', async function () {
+            it('ingestFromStream', async () => {
                 for (const item of testItems) {
                     let stream: ReadStream | StreamDescriptor = fs.createReadStream(item.path);
                     if (item.path.endsWith('gz')) {
@@ -149,8 +149,8 @@ function main(): void {
             }).timeout(240000);
         });
 
-        describe('StreamingIngestClient', function () {
-            it('ingestFromFile', async function () {
+        describe('StreamingIngestClient', () => {
+            it('ingestFromFile', async () => {
                 for (const item of testItems.filter(i => i.testOnstreamingIngestion)) {
                     try {
                         await streamingIngestClient.ingestFromFile(item.path, item.ingestionProperties);
@@ -161,7 +161,7 @@ function main(): void {
                 }
             }).timeout(240000);
 
-            it('ingestFromStream', async function () {
+            it('ingestFromStream', async () => {
                 for (const item of testItems.filter(i => i.testOnstreamingIngestion)) {
                     let stream: ReadStream | StreamDescriptor = fs.createReadStream(item.path);
                     if (item.path.endsWith('gz')) {
@@ -177,8 +177,8 @@ function main(): void {
             }).timeout(240000);
         });
 
-        describe('ManagedStreamingIngestClient', function () {
-            it('ingestFromFile', async function () {
+        describe('ManagedStreamingIngestClient', () => {
+            it('ingestFromFile', async () => {
                 for (const item of testItems.filter(i => i.testOnstreamingIngestion)) {
                     try {
                         await managedStreamingIngestClient.ingestFromFile(item.path, item.ingestionProperties);
@@ -189,7 +189,7 @@ function main(): void {
                     await assertRowsCount(item);
                 }
             }).timeout(240000);
-            it('ingestFromStream', async function () {
+            it('ingestFromStream', async () => {
                 for (const item of testItems.filter(i => i.testOnstreamingIngestion)) {
                     let stream: ReadStream | StreamDescriptor = fs.createReadStream(item.path);
                     if (item.path.endsWith('gz')) {
@@ -205,8 +205,8 @@ function main(): void {
             }).timeout(240000);
         });
 
-        describe('KustoIngestStatusQueues', function () {
-            it('CleanStatusQueues', async function () {
+        describe('KustoIngestStatusQueues', () => {
+            it('CleanStatusQueues', async () => {
                 try {
                     await cleanStatusQueues();
                 } catch (err) {
@@ -215,7 +215,7 @@ function main(): void {
                 }
             }).timeout(240000);
 
-            it('CheckSucceededIngestion', async function () {
+            it('CheckSucceededIngestion', async () => {
                 const item = testItems[0];
                 item.ingestionProperties.reportLevel = ReportLevel.FailuresAndSuccesses;
                 try {
@@ -229,7 +229,7 @@ function main(): void {
                 }
             }).timeout(240000);
 
-            it('CheckFailedIngestion', async function () {
+            it('CheckFailedIngestion', async () => {
                 const item = testItems[0];
                 item.ingestionProperties.reportLevel = ReportLevel.FailuresAndSuccesses;
                 item.ingestionProperties.database = "invalid";
@@ -245,8 +245,8 @@ function main(): void {
             }).timeout(240000);
         });
 
-        describe('QueryClient', function () {
-            it('General BadRequest', async function () {
+        describe('QueryClient', () => {
+            it('General BadRequest', async () => {
                 try {
                     await queryClient.executeQuery(databaseName, "invalidSyntax ");
                 } catch (ex) {
@@ -255,7 +255,7 @@ function main(): void {
                 assert.fail(`General BadRequest`);
             });
 
-            it('PartialQueryFailure', async function () {
+            it('PartialQueryFailure', async () => {
                 try {
                     await queryClient.executeQuery(databaseName, "invalidSyntax ");
 
@@ -265,7 +265,7 @@ function main(): void {
                 assert.fail(`Didn't throw PartialQueryFailure`);
             });
 
-            it('executionTimeout', async function () {
+            it('executionTimeout', async () => {
                 try {
                     const properties = new ClientRequestProperties();
                     properties.setTimeout(10);

--- a/azure-kusto-ingest/test/e2eTests/e2eTest.ts
+++ b/azure-kusto-ingest/test/e2eTests/e2eTest.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+/* tslint:disable:no-console */
+
 import assert from "assert";
 import fs, {ReadStream} from 'fs';
 import IngestClient from "../../source/ingestClient";
@@ -35,8 +37,8 @@ function main(): void {
     const ingestClient = new IngestClient(dmKcsb);
     const statusQueues = new KustoIngestStatusQueues(ingestClient);
     const managedStreamingIngestClient = new ManagedStreamingIngestClient(engineKcsb, dmKcsb);
-  
-    class testDataItem {
+
+    class TestDataItem {
         constructor(public description: string, public path: string, public rows: number, public ingestionProperties: IngestionProperties, public testOnstreamingIngestion = true) {
         }
     }
@@ -70,12 +72,12 @@ function main(): void {
     });
 
     const testItems = [
-        new testDataItem("csv", getTestResourcePath("dataset.csv"), 10, ingestionPropertiesWithoutMapping),
-        new testDataItem("csv.gz", getTestResourcePath("dataset_gzip.csv.gz"), 10, ingestionPropertiesWithoutMapping),
-        new testDataItem("json with mapping ref", getTestResourcePath("dataset.json"), 2, ingestionPropertiesWithMappingReference),
-        new testDataItem("json.gz with mapping ref", getTestResourcePath("dataset_gzip.json.gz"), 2, ingestionPropertiesWithMappingReference),
-        new testDataItem("json with mapping", getTestResourcePath("dataset.json"), 2, ingestionPropertiesWithColumnMapping, false),
-        new testDataItem("json.gz with mapping", getTestResourcePath("dataset_gzip.json.gz"), 2, ingestionPropertiesWithColumnMapping, false)
+        new TestDataItem("csv", getTestResourcePath("dataset.csv"), 10, ingestionPropertiesWithoutMapping),
+        new TestDataItem("csv.gz", getTestResourcePath("dataset_gzip.csv.gz"), 10, ingestionPropertiesWithoutMapping),
+        new TestDataItem("json with mapping ref", getTestResourcePath("dataset.json"), 2, ingestionPropertiesWithMappingReference),
+        new TestDataItem("json.gz with mapping ref", getTestResourcePath("dataset_gzip.json.gz"), 2, ingestionPropertiesWithMappingReference),
+        new TestDataItem("json with mapping", getTestResourcePath("dataset.json"), 2, ingestionPropertiesWithColumnMapping, false),
+        new TestDataItem("json.gz with mapping", getTestResourcePath("dataset_gzip.json.gz"), 2, ingestionPropertiesWithColumnMapping, false)
     ];
 
     let currentCount = 0;
@@ -149,7 +151,7 @@ function main(): void {
 
         describe('StreamingIngestClient', function () {
             it('ingestFromFile', async function () {
-                for (const item of testItems.filter(item => item.testOnstreamingIngestion)) {
+                for (const item of testItems.filter(i => i.testOnstreamingIngestion)) {
                     try {
                         await streamingIngestClient.ingestFromFile(item.path, item.ingestionProperties);
                     } catch (err) {
@@ -160,7 +162,7 @@ function main(): void {
             }).timeout(240000);
 
             it('ingestFromStream', async function () {
-                for (const item of testItems.filter(item => item.testOnstreamingIngestion)) {
+                for (const item of testItems.filter(i => i.testOnstreamingIngestion)) {
                     let stream: ReadStream | StreamDescriptor = fs.createReadStream(item.path);
                     if (item.path.endsWith('gz')) {
                         stream = new StreamDescriptor(stream, null, CompressionType.GZIP);
@@ -177,7 +179,7 @@ function main(): void {
 
         describe('ManagedStreamingIngestClient', function () {
             it('ingestFromFile', async function () {
-                for (const item of testItems.filter(item => item.testOnstreamingIngestion)) {
+                for (const item of testItems.filter(i => i.testOnstreamingIngestion)) {
                     try {
                         await managedStreamingIngestClient.ingestFromFile(item.path, item.ingestionProperties);
                     } catch (err) {
@@ -188,7 +190,7 @@ function main(): void {
                 }
             }).timeout(240000);
             it('ingestFromStream', async function () {
-                for (const item of testItems.filter(item => item.testOnstreamingIngestion)) {
+                for (const item of testItems.filter(i => i.testOnstreamingIngestion)) {
                     let stream: ReadStream | StreamDescriptor = fs.createReadStream(item.path);
                     if (item.path.endsWith('gz')) {
                         stream = new StreamDescriptor(stream, null, CompressionType.GZIP);
@@ -303,7 +305,7 @@ function main(): void {
         return __dirname + `/e2eData/${name}`;
     }
 
-    async function assertRowsCount(testItem: testDataItem) {
+    async function assertRowsCount(testItem: TestDataItem) {
         let count = 0;
         const expected = testItem.rows;
         // Timeout = 3 min

--- a/azure-kusto-ingest/test/ingestClientTest.ts
+++ b/azure-kusto-ingest/test/ingestClientTest.ts
@@ -6,9 +6,9 @@ import {KustoIngestClient} from "../source/ingestClient";
 import {DataFormat, IngestionProperties} from "../source/ingestionProperties";
 
 
-describe("KustoIngestClient", function () {
-    describe("#constructor()", function () {
-        it("valid input", function () {
+describe("KustoIngestClient", () => {
+    describe("#constructor()", () => {
+        it("valid input", () => {
             const ingestClient = new KustoIngestClient("https://cluster.kusto.windows.net", {
                 database: "db",
                 table: "table",
@@ -23,8 +23,8 @@ describe("KustoIngestClient", function () {
         });
     });
 
-    describe("#_resolveProperties()", function () {
-        it("empty default props", function () {
+    describe("#_resolveProperties()", () => {
+        it("empty default props", () => {
             const newProps = new IngestionProperties({
                 database: "db",
                 table: "table",
@@ -39,7 +39,7 @@ describe("KustoIngestClient", function () {
             assert.strictEqual(actual.format, "csv");
         });
 
-        it("empty new props", function () {
+        it("empty new props", () => {
             // TODO: not sure a unit test will be useful here
             const defaultProps = new IngestionProperties({
                 database: "db",
@@ -55,7 +55,7 @@ describe("KustoIngestClient", function () {
             assert.strictEqual(actual.format, "csv");
         });
 
-        it("both exist props", function () {
+        it("both exist props", () => {
             const defaultProps = new IngestionProperties({
                 database: "db",
                 table: "table",
@@ -74,7 +74,7 @@ describe("KustoIngestClient", function () {
             assert.strictEqual(actual.ingestionMappingReference, "MappingRef");
         });
 
-        it("empty both", function () {
+        it("empty both", () => {
             const client = new KustoIngestClient('https://cluster.region.kusto.windows.net');
 
             const actual = client._mergeProps();
@@ -82,20 +82,20 @@ describe("KustoIngestClient", function () {
         });
     });
 
-    describe("#ingestFromFile()", function () {
-        it("valid input", function () {
+    describe("#ingestFromFile()", () => {
+        it("valid input", () => {
             // TODO: not sure a unit test will be useful here
         });
     });
 
-    describe("#ingestFromStream()", function () {
-        it("valid input", function () {
+    describe("#ingestFromStream()", () => {
+        it("valid input", () => {
             // TODO: not sure a unit test will be useful here
         });
     });
 
-    describe("#ingestFromBlob()", function () {
-        it("valid input", function () {
+    describe("#ingestFromBlob()", () => {
+        it("valid input", () => {
             // TODO: not sure a unit test will be useful here
         });
     });

--- a/azure-kusto-ingest/test/ingestionPropsTest.ts
+++ b/azure-kusto-ingest/test/ingestionPropsTest.ts
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 
 import assert from "assert";
-import {IngestionProperties, JsonColumnMapping} from "../source/ingestionProperties";
+import { DataFormat, IngestionProperties, JsonColumnMapping } from "../source/ingestionProperties";
 
 import {IngestionBlobInfo} from "../source/ingestionBlobInfo";
 import {BlobDescriptor} from "../source/descriptors";
 
-const { DataFormat } = require("../source/ingestionProperties");
+
 
 describe("IngestionProperties", function () {
     describe("#constructor()", function () {

--- a/azure-kusto-ingest/test/ingestionPropsTest.ts
+++ b/azure-kusto-ingest/test/ingestionPropsTest.ts
@@ -9,9 +9,9 @@ import {BlobDescriptor} from "../source/descriptors";
 
 
 
-describe("IngestionProperties", function () {
-    describe("#constructor()", function () {
-        it("valid input", function () {
+describe("IngestionProperties", () => {
+    describe("#constructor()", () => {
+        it("valid input", () => {
             const props = new IngestionProperties({database: "db", table: "table", format: DataFormat.CSV});
 
             assert.strictEqual(props.database, "db");
@@ -20,8 +20,8 @@ describe("IngestionProperties", function () {
         });
     });
 
-    describe("#merge()", function () {
-        it("valid input", function () {
+    describe("#merge()", () => {
+        it("valid input", () => {
             const props = new IngestionProperties({database: "db", table: "table", format: DataFormat.CSV});
 
             const otherProps = new IngestionProperties({ingestionMappingReference: "CsvMappingRef"});
@@ -35,8 +35,8 @@ describe("IngestionProperties", function () {
         });
     });
 
-    describe("#validate()", function () {
-        it("valid input", function () {
+    describe("#validate()", () => {
+        it("valid input", () => {
             const props = new IngestionProperties({database: "db", table: "table", format: DataFormat.CSV, ingestionMappingReference: "CsvMappingRef"});
 
             try {
@@ -46,7 +46,7 @@ describe("IngestionProperties", function () {
             }
         });
 
-        it("invalid input", function () {
+        it("invalid input", () => {
             const props = new IngestionProperties({});
 
             try {
@@ -56,7 +56,7 @@ describe("IngestionProperties", function () {
             }
         });
 
-        it("invalid input json", function () {
+        it("invalid input json", () => {
             const props = new IngestionProperties({database: "db", table: "table", format: DataFormat.JSON});
 
             try {
@@ -66,7 +66,7 @@ describe("IngestionProperties", function () {
             }
         });
 
-        it("json mapping as additional props on ingestion blob info", function () {
+        it("json mapping as additional props on ingestion blob info", () => {
             const columns = [new JsonColumnMapping('Id', '$.Id', 'int'), new JsonColumnMapping('Value', '$.value', 'dynamic')];
             const props = new IngestionProperties({database: "db", table: "table", format: DataFormat.CSV, ingestionMapping: columns});
             const ingestionBlobInfo = new IngestionBlobInfo(new BlobDescriptor('https://account.blob.core.windows.net/blobcontainer/blobfile.json'), props);

--- a/azure-kusto-ingest/test/managedStreamingIngestClientTest.ts
+++ b/azure-kusto-ingest/test/managedStreamingIngestClientTest.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+/* tslint:disable:no-console */
+
 import sinon from "sinon";
 import { StreamingIngestClient } from "../index";
 import { StreamDescriptor } from "../source/descriptors";
@@ -46,7 +48,7 @@ describe("ManagedStreamingIngestClient", function () {
         };
 
         stream.on('data', function (data: Buffer) {
-            console.log(data.toString("utf-8").substring(0, 100));
+            console.debug(data.toString("utf-8").substring(0, 100));
         });
         return stream;
     }
@@ -87,7 +89,7 @@ describe("ManagedStreamingIngestClient", function () {
         }
     }
 
-    CloudSettings.getInstance().cloudCache["engine"] = CloudSettings.getInstance().defaultCloudInfo;
+    CloudSettings.getInstance().cloudCache.engine = CloudSettings.getInstance().defaultCloudInfo;
 
     const testUuid = "9c565db6-ddcd-4b2d-bb6e-17525aab254d";
 
@@ -100,7 +102,7 @@ describe("ManagedStreamingIngestClient", function () {
                 queuedStub.throws(new Error("Should not be called"));
 
 
-                let items = [
+                const items = [
                     Buffer.alloc(1024 * 1024, "a"),
                     Buffer.alloc(1024 * 1024, "b"),
                     Buffer.alloc(1024 * 1024, "c"),
@@ -130,11 +132,11 @@ describe("ManagedStreamingIngestClient", function () {
                 // Mock ManagedStreamingIngestClient with mocked streamingIngestClient
                 const transientError = { "@permanent": false };
                 streamStub.throws(transientError);
-                queuedStub.returns(Promise.resolve(<QueueSendMessageResponse>{}));
+                queuedStub.returns(Promise.resolve({} as QueueSendMessageResponse));
 
                 managedClient._mergeProps()
 
-                let items = [Buffer.from("string1"), Buffer.from("string2"), Buffer.from("string3")];
+                const items = [Buffer.from("string1"), Buffer.from("string2"), Buffer.from("string3")];
                 const stream = createStream(items);
 
                 await managedClient.ingestFromStream(new StreamDescriptor(stream, sourceId), new IngestionProperties({
@@ -155,18 +157,18 @@ describe("ManagedStreamingIngestClient", function () {
                 const mockedStreamingIngestClient = new StreamingIngestClient("engine");
                 const mockedIngestClient = new KustoIngestClient("engine");
                 const sandbox = sinon.createSandbox();
-                let streamStub = sinon.stub(mockedStreamingIngestClient, "ingestFromStream");
+                const streamStub = sinon.stub(mockedStreamingIngestClient, "ingestFromStream");
                 streamStub.throws(new Error("Should not be called"));
-                let queuedStub = sinon.stub(mockedIngestClient, "ingestFromStream");
-                queuedStub.returns(Promise.resolve(<QueueSendMessageResponse>{}));
+                const queuedStub = sinon.stub(mockedIngestClient, "ingestFromStream");
+                queuedStub.returns(Promise.resolve({} as QueueSendMessageResponse));
                 const mockedManagedStreamingIngestClient: KustoManagedStreamingIngestClient =
                     Object.setPrototypeOf({
                         streamingIngestClient: mockedStreamingIngestClient,
                         queuedIngestClient: mockedIngestClient, maxRetries: 1, baseSleepTimeSecs: 0, baseJitterSecs: 0
                     }, KustoManagedStreamingIngestClient.prototype);
 
-                let singleBufferSize = 1023 * 1024;
-                let buffers = [
+                const singleBufferSize = 1023 * 1024;
+                const buffers = [
                     Buffer.alloc(singleBufferSize, "a"),
                     Buffer.alloc(singleBufferSize, "b"),
                     Buffer.alloc(singleBufferSize, "c"),

--- a/azure-kusto-ingest/test/managedStreamingIngestClientTest.ts
+++ b/azure-kusto-ingest/test/managedStreamingIngestClientTest.ts
@@ -21,7 +21,7 @@ import { KustoConnectionStringBuilder } from "azure-kusto-data";
 
 type IngestFromStreamStub = Sinon.SinonStub<[(StreamDescriptor | Readable), IngestionProperties, string?], Promise<QueueSendMessageResponse>>;
 
-describe("ManagedStreamingIngestClient", function () {
+describe("ManagedStreamingIngestClient", () => {
     function getMockedClient() {
         const sandbox = sinon.createSandbox();
         const mockedStreamingIngestClient = new StreamingIngestClient("engine");
@@ -47,7 +47,7 @@ describe("ManagedStreamingIngestClient", function () {
             stream.push(null);
         };
 
-        stream.on('data', function (data: Buffer) {
+        stream.on('data', (data: Buffer) => {
             console.debug(data.toString("utf-8").substring(0, 100));
         });
         return stream;
@@ -93,9 +93,9 @@ describe("ManagedStreamingIngestClient", function () {
 
     const testUuid = "9c565db6-ddcd-4b2d-bb6e-17525aab254d";
 
-    describe("standard", function () {
+    describe("standard", () => {
         for (const sourceId of [null, testUuid]){
-            it(`should use streaming ingest with sourceId ${sourceId}`, async function () {
+            it(`should use streaming ingest with sourceId ${sourceId}`, async () => {
                 const { managedClient, queuedStub, sandbox, streamStub } = getMockedClient();
 
                 streamStub.returns(Promise.resolve({}));
@@ -124,9 +124,9 @@ describe("ManagedStreamingIngestClient", function () {
 
     });
 
-    describe("fallback", function () {
+    describe("fallback", () => {
         for (const sourceId of [null, testUuid]) {
-            it(`should fall to queued when transient error with sourceId ${sourceId}`, async function () {
+            it(`should fall to queued when transient error with sourceId ${sourceId}`, async () => {
                 const { managedClient, queuedStub, sandbox, streamStub } = getMockedClient();
 
                 // Mock ManagedStreamingIngestClient with mocked streamingIngestClient
@@ -152,7 +152,7 @@ describe("ManagedStreamingIngestClient", function () {
                 validateStream(queuedStub, items, sourceId);
             });
 
-            it('should fallback when size is too big', async function () {
+            it('should fallback when size is too big', async () => {
                 // Mock ManagedStreamingIngestClient with mocked streamingIngestClient
                 const mockedStreamingIngestClient = new StreamingIngestClient("engine");
                 const mockedIngestClient = new KustoIngestClient("engine");
@@ -193,8 +193,8 @@ describe("ManagedStreamingIngestClient", function () {
         }
     });
 
-    describe("helper methods", function () {
-        it("should be able to create a ManagedStreamingIngestClient from a DM URI", function () {
+    describe("helper methods", () => {
+        it("should be able to create a ManagedStreamingIngestClient from a DM URI", () => {
             const client = KustoManagedStreamingIngestClient.fromDmConnectionString(KustoConnectionStringBuilder.withAccessToken("https://ingest-dummy.kusto.windows.net"));
 
             assert.strictEqual((client as any).queuedIngestClient.resourceManager.kustoClient.connectionString.dataSource,
@@ -202,10 +202,10 @@ describe("ManagedStreamingIngestClient", function () {
             assert.strictEqual((client as any).streamingIngestClient.kustoClient.connectionString.dataSource,
                 "https://dummy.kusto.windows.net");
         });
-        it("should fail when trying to create a ManagedStreamingIngestClient from an invalid DM URI", function () {
+        it("should fail when trying to create a ManagedStreamingIngestClient from an invalid DM URI", () => {
             assert.throws(() => KustoManagedStreamingIngestClient.fromDmConnectionString(KustoConnectionStringBuilder.withAccessToken("https://dummy.kusto.windows.net")));
         });
-        it("should be able to create a ManagedStreamingIngestClient from an Engine URI", function () {
+        it("should be able to create a ManagedStreamingIngestClient from an Engine URI", () => {
             const client = KustoManagedStreamingIngestClient.fromEngineConnectionString(KustoConnectionStringBuilder.withAccessToken("https://dummy.kusto.windows.net"));
 
             assert.strictEqual((client as any).queuedIngestClient.resourceManager.kustoClient.connectionString.dataSource,
@@ -213,7 +213,7 @@ describe("ManagedStreamingIngestClient", function () {
             assert.strictEqual((client as any).streamingIngestClient.kustoClient.connectionString.dataSource,
                 "https://dummy.kusto.windows.net");
         });
-        it("should fail when trying to create a ManagedStreamingIngestClient from an invalid Engine URI", function () {
+        it("should fail when trying to create a ManagedStreamingIngestClient from an invalid Engine URI", () => {
             assert.throws(() => KustoManagedStreamingIngestClient.fromEngineConnectionString(KustoConnectionStringBuilder.withAccessToken("https://ingest-dummy.kusto.windows.net")));
         });
     });

--- a/azure-kusto-ingest/test/resourceManagerTest.ts
+++ b/azure-kusto-ingest/test/resourceManagerTest.ts
@@ -12,9 +12,9 @@ import {Client as KustoClient} from "azure-kusto-data";
 import {IngestClientResources, ResourceManager, ResourceURI} from "../source/resourceManager";
 import {KustoResponseDataSet} from "azure-kusto-data/source/response";
 
-describe("ResourceURI", function () {
-    describe("#fromUri()", function () {
-        it("valid input", function () {
+describe("ResourceURI", () => {
+    describe("#fromUri()", () => {
+        it("valid input", () => {
             const accountName = "account";
             const objectType = "blob";
             const objectName = "container";
@@ -30,8 +30,8 @@ describe("ResourceURI", function () {
         });
     });
 
-    describe("#getSASConnectionString()", function () {
-        it("valid input", function () {
+    describe("#getSASConnectionString()", () => {
+        it("valid input", () => {
             const accountName = "account";
             const objectType = "blob";
             const objectName = "container";
@@ -46,7 +46,7 @@ describe("ResourceURI", function () {
 });
 
 
-describe("ResourceManager", function () {
+describe("ResourceManager", () => {
     const rows = [
         { ResourceTypeName: "SecuredReadyForAggregationQueue", StorageRoot: "https://account.queue.core.windows.net/ready1?sas" },
         { ResourceTypeName: "FailedIngestionsQueue", StorageRoot: "https://account.queue.core.windows.net/failed?sas" },
@@ -66,8 +66,8 @@ describe("ResourceManager", function () {
         }]
     };
 
-    describe("#constructor()", function () {
-        it("valid input", function () {
+    describe("#constructor()", () => {
+        it("valid input", () => {
             const resourceManager = new ResourceManager(new KustoClient("https://cluster.kusto.windows.net"));
 
             assert.strictEqual(resourceManager.ingestClientResources, null);
@@ -75,8 +75,8 @@ describe("ResourceManager", function () {
         });
     });
 
-    describe("#getIngestClientResourcesFromService()", function () {
-        it("valid input", async function () {
+    describe("#getIngestClientResourcesFromService()", () => {
+        it("valid input", async () => {
             const client = new KustoClient("https://cluster.kusto.windows.net")
             sinon.stub(client, "execute").returns(Promise.resolve(mockedResourcesResponse as KustoResponseDataSet));
 
@@ -90,7 +90,7 @@ describe("ResourceManager", function () {
         });
 
 
-        it("error response", async function () {
+        it("error response", async () => {
             const client = new KustoClient("https://cluster.kusto.windows.net");
             sinon.stub(client, "execute").throwsException(new Error("Kusto request erred (403)"));
 
@@ -106,8 +106,8 @@ describe("ResourceManager", function () {
         });
     });
 
-    describe("#getResourceByName()", function () {
-        it("valid input", function () {
+    describe("#getResourceByName()", () => {
+        it("valid input", () => {
             const resourceManager = new ResourceManager(new KustoClient("https://cluster.kusto.windows.net"));
 
             const resources = resourceManager.getResourceByName(mockedResourcesResponse.primaryResults[0], "TempStorage");
@@ -115,8 +115,8 @@ describe("ResourceManager", function () {
         });
     });
 
-    describe("#refreshIngestClientResources()", function () {
-        it("should refresh", async function () {
+    describe("#refreshIngestClientResources()", () => {
+        it("should refresh", async () => {
             const resourceManager = new ResourceManager(new KustoClient("https://cluster.kusto.windows.net"));
 
             const call = sinon.stub(resourceManager, "getIngestClientResourcesFromService");
@@ -125,7 +125,7 @@ describe("ResourceManager", function () {
             assert.strictEqual(call.calledOnce, true);
         });
 
-        it("shouldn't refresh", async function () {
+        it("shouldn't refresh", async () => {
             const resourceManager = new ResourceManager(new KustoClient("https://cluster.kusto.windows.net"));
 
             const call = sinon.stub(resourceManager, "getIngestClientResourcesFromService");

--- a/azure-kusto-ingest/tslint.json
+++ b/azure-kusto-ingest/tslint.json
@@ -10,9 +10,6 @@
       "only-arrow-functions": false
     },
     "linterOptions": {
-      "exclude": [
-        "./test/**/*"
-      ]
     },
     "rulesDirectory": []
 }

--- a/azure-kusto-ingest/tslint.json
+++ b/azure-kusto-ingest/tslint.json
@@ -4,11 +4,7 @@
         "tslint:recommended"
     ],
     "jsRules": {},
-    "rules": {
-      "max-classes-per-file": false,
-      "triple-equals": false,
-      "only-arrow-functions": false
-    },
+    "rules": {},
     "linterOptions": {
     },
     "rulesDirectory": []


### PR DESCRIPTION
-Turned on linter for test files and fixed results
-Replaced deprecated assert.equals with assert.strictEquals