### PR TITLE
Update azure identity to 2.0.0 to fix security bug

### DIFF
--- a/azure-kusto-data/package-lock.json
+++ b/azure-kusto-data/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.3",
       "license": "ISC",
       "dependencies": {
-        "@azure/identity": "^1.3.0",
+        "@azure/identity": "^2.0.1",
         "@azure/msal-node": "^1.5.0",
         "@types/node": "^14.14.13",
         "@types/uuid": "^8.3.0",
@@ -33,7 +33,8 @@
     },
     "node_modules/@azure/abort-controller": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.4.tgz",
+      "integrity": "sha512-lNUmDRVGpanCsiUN3NWxFTdwmdFI53xwhkTFfHDGTYk46ca7Ind3nanJc+U6Zj9Tv+9nTCWRBscWEW1DyKOpTw==",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -42,137 +43,136 @@
       }
     },
     "node_modules/@azure/abort-controller/node_modules/tslib": {
-      "version": "2.3.0",
-      "license": "0BSD"
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@azure/core-asynciterator-polyfill": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
+      "integrity": "sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg=="
     },
     "node_modules/@azure/core-auth": {
-      "version": "1.3.0",
-      "license": "MIT",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.3.2.tgz",
+      "integrity": "sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
-        "tslib": "^2.0.0"
+        "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@azure/core-auth/node_modules/tslib": {
-      "version": "2.3.0",
-      "license": "0BSD"
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
-    "node_modules/@azure/core-http": {
-      "version": "1.2.6",
-      "license": "MIT",
+    "node_modules/@azure/core-client": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.4.0.tgz",
+      "integrity": "sha512-6v1pn4ubNSeI56PUgj2NLR/nfoMfkjYmrtNX0YdXrjxSajKcf/TZc/QJtTFj4wHIvYqU/Yn/g/Zb+MNhFZ5c+Q==",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-asynciterator-polyfill": "^1.0.0",
         "@azure/core-auth": "^1.3.0",
-        "@azure/core-tracing": "1.0.0-preview.11",
+        "@azure/core-rest-pipeline": "^1.4.0",
+        "@azure/core-tracing": "1.0.0-preview.13",
         "@azure/logger": "^1.0.0",
-        "@types/node-fetch": "^2.5.0",
-        "@types/tunnel": "^0.0.1",
-        "form-data": "^3.0.0",
-        "node-fetch": "^2.6.0",
-        "process": "^0.11.10",
-        "tough-cookie": "^4.0.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@azure/core-client/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.4.0.tgz",
+      "integrity": "sha512-M2uL9PbvhJIEMRoUad3EnXCHWLN/i0W7D7MQJ9rnIDW7iLVCteUiegdqNa2Cr1/7he/ysEXYiwaXiHmfack/6g==",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-tracing": "1.0.0-preview.13",
+        "@azure/logger": "^1.0.0",
+        "form-data": "^4.0.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
         "tslib": "^2.2.0",
-        "tunnel": "^0.0.6",
-        "uuid": "^8.3.0",
-        "xml2js": "^0.4.19"
+        "uuid": "^8.3.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.0.0"
       }
     },
-    "node_modules/@azure/core-http/node_modules/form-data": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@azure/core-http/node_modules/tough-cookie": {
-      "version": "4.0.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@azure/core-http/node_modules/tslib": {
-      "version": "2.3.0",
-      "license": "0BSD"
+    "node_modules/@azure/core-rest-pipeline/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@azure/core-tracing": {
-      "version": "1.0.0-preview.11",
-      "license": "MIT",
+      "version": "1.0.0-preview.13",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
+      "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
       "dependencies": {
-        "@opencensus/web-types": "0.0.7",
-        "@opentelemetry/api": "1.0.0-rc.0",
+        "@opentelemetry/api": "^1.0.1",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.0.0-beta.1.tgz",
+      "integrity": "sha512-pS6cup979/qyuyNP9chIybK2qVkJ3MarbY/bx3JcGKE6An6dRweLnsfJfU2ydqUI/B51Rjnn59ajHIhCUTwWZw==",
+      "dependencies": {
         "tslib": "^2.0.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@azure/core-tracing/node_modules/tslib": {
-      "version": "2.3.0",
-      "license": "0BSD"
+    "node_modules/@azure/core-util/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@azure/identity": {
-      "version": "1.3.0",
-      "license": "MIT",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-2.0.1.tgz",
+      "integrity": "sha512-gdGGuLKlKIQaf2RefA84keoBfmWfiAntbW2SzcdKvwLSGzsio/qkyY3sYUpXRz/sqLDxguuimgZukp7TPgwIlg==",
       "dependencies": {
-        "@azure/core-http": "^1.2.4",
-        "@azure/core-tracing": "1.0.0-preview.11",
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-client": "^1.0.0",
+        "@azure/core-rest-pipeline": "^1.1.0",
+        "@azure/core-tracing": "1.0.0-preview.13",
+        "@azure/core-util": "^1.0.0-beta.1",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-node": "1.0.0-beta.6",
+        "@azure/msal-browser": "^2.16.0",
+        "@azure/msal-common": "^4.5.1",
+        "@azure/msal-node": "^1.3.0",
         "@types/stoppable": "^1.1.0",
-        "axios": "^0.21.1",
         "events": "^3.0.0",
         "jws": "^4.0.0",
-        "msal": "^1.0.2",
-        "open": "^7.0.0",
-        "qs": "^6.7.0",
+        "open": "^8.0.0",
         "stoppable": "^1.1.0",
-        "tslib": "^2.0.0",
+        "tslib": "^2.2.0",
         "uuid": "^8.3.0"
       },
       "engines": {
-        "node": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "keytar": "^7.3.0"
-      }
-    },
-    "node_modules/@azure/identity/node_modules/@azure/msal-node": {
-      "version": "1.0.0-beta.6",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/msal-common": "^4.0.0",
-        "axios": "^0.21.1",
-        "jsonwebtoken": "^8.5.1",
-        "uuid": "^8.3.0"
-      }
-    },
-    "node_modules/@azure/identity/node_modules/axios": {
-      "version": "0.21.4",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@azure/identity/node_modules/jwa": {
@@ -192,40 +192,52 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/@azure/identity/node_modules/qs": {
-      "version": "6.10.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/@azure/identity/node_modules/tslib": {
       "version": "2.3.0",
       "license": "0BSD"
     },
     "node_modules/@azure/logger": {
-      "version": "1.0.2",
-      "license": "MIT",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
+      "integrity": "sha512-aK4s3Xxjrx3daZr3VylxejK3vG5ExXck5WOHDJ8in/k9AqlfIyFMMT1uG7u8mNjX+QRILTIn0/Xgschfh/dQ9g==",
       "dependencies": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@azure/logger/node_modules/tslib": {
-      "version": "2.3.0",
-      "license": "0BSD"
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.21.0.tgz",
+      "integrity": "sha512-y+oAUJJ0m7gRUT505iGT4SDXktrRzOE3HZC0+nQyHDI+3O7BKK5NjQUwD/4V8FNNyrhxEtLk99iwJEo61epinQ==",
+      "dependencies": {
+        "@azure/msal-common": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.0.0.tgz",
+      "integrity": "sha512-Vva3snqmWPHJNDCBb4lz3D0rvZsi/0QikAxHvVFNwtNg5pP4NZE4U34tNiXN+m9KhlQFrZBPkE5rk7dIEOGcWw==",
+      "dependencies": {
+        "debug": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/@azure/msal-common": {
-      "version": "4.3.0",
-      "license": "MIT",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-4.5.1.tgz",
+      "integrity": "sha512-/i5dXM+QAtO+6atYd5oHGBAx48EGSISkXNXViheliOQe+SIFMDo3gSq3lL54W0suOSAsVPws3XnTaIHlla0PIQ==",
       "dependencies": {
         "debug": "^4.1.1"
       },
@@ -625,16 +637,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/@opencensus/web-types": {
-      "version": "0.0.7",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
     "node_modules/@opentelemetry/api": {
-      "version": "1.0.0-rc.0",
-      "license": "Apache-2.0",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
+      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -671,6 +677,14 @@
       "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
     },
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@types/mocha": {
       "version": "8.2.0",
       "dev": true,
@@ -680,22 +694,8 @@
       "version": "14.14.13",
       "license": "MIT"
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.5.4",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/stoppable": {
       "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/tunnel": {
-      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -709,6 +709,17 @@
       "version": "1.1.2",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
@@ -728,14 +739,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ansi-styles": {
@@ -772,24 +775,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/aproba": {
-      "version": "1.2.0",
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/archy": {
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "1.1.5",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -811,7 +800,8 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/axios": {
       "version": "0.24.0",
@@ -825,54 +815,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/brace-expansion": {
@@ -922,29 +870,6 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "license": "BSD-3-Clause"
@@ -974,17 +899,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/camelcase": {
@@ -1051,11 +965,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "dev": true,
@@ -1095,14 +1004,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/code-point-at": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "dev": true,
@@ -1118,7 +1019,8 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -1141,11 +1043,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
       "dev": true,
@@ -1158,11 +1055,6 @@
       "version": "5.1.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1213,25 +1105,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "4.2.1",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mimic-response": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/default-require-extensions": {
       "version": "3.0.0",
       "dev": true,
@@ -1243,27 +1116,20 @@
         "node": ">=8"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "license": "MIT",
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "engines": {
-        "node": ">=0.4.0"
+        "node": ">=8"
       }
     },
-    "node_modules/delegates": {
+    "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "license": "Apache-2.0",
-      "optional": true,
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "engines": {
-        "node": ">=0.10"
+        "node": ">=0.4.0"
       }
     },
     "node_modules/diff": {
@@ -1290,14 +1156,6 @@
       "version": "8.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "once": "^1.4.0"
-      }
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
@@ -1337,14 +1195,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
-      }
-    },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "license": "(MIT OR WTFPL)",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/fill-range": {
@@ -1427,6 +1277,19 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fromentries": {
       "version": "1.3.2",
       "dev": true,
@@ -1446,11 +1309,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "dev": true,
@@ -1458,33 +1316,8 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/gauge": {
-      "version": "2.7.4",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "node_modules/gauge/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -1502,18 +1335,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "dev": true,
@@ -1521,11 +1342,6 @@
       "engines": {
         "node": ">=8.0.0"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/glob": {
       "version": "7.2.0",
@@ -1580,6 +1396,7 @@
     },
     "node_modules/has": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1"
@@ -1595,21 +1412,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/hasha": {
       "version": "5.2.2",
@@ -1639,24 +1441,30 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true
+    "node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
@@ -1685,13 +1493,8 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -1717,7 +1520,8 @@
     },
     "node_modules/is-docker": {
       "version": "2.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "bin": {
         "is-docker": "cli.js"
       },
@@ -1732,17 +1536,6 @@
       "version": "2.1.1",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1811,7 +1604,8 @@
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -2037,16 +1831,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/keytar": {
-      "version": "7.7.0",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-addon-api": "^3.0.0",
-        "prebuild-install": "^6.0.0"
-      }
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "dev": true,
@@ -2226,31 +2010,22 @@
       "license": "MIT"
     },
     "node_modules/mime-db": {
-      "version": "1.42.0",
-      "license": "MIT",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.25",
-      "license": "MIT",
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
       "dependencies": {
-        "mime-db": "1.42.0"
+        "mime-db": "1.51.0"
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/mimic-response": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -2266,7 +2041,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mkdirp": {
@@ -2279,11 +2054,6 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/mocha": {
       "version": "9.2.0",
@@ -2439,16 +2209,6 @@
       "version": "2.1.2",
       "license": "MIT"
     },
-    "node_modules/msal": {
-      "version": "1.4.11",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/nanoid": {
       "version": "3.2.0",
       "dev": true,
@@ -2460,11 +2220,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/nise": {
       "version": "1.5.2",
       "dev": true,
@@ -2475,37 +2230,6 @@
         "just-extend": "^4.0.2",
         "lolex": "^4.1.0",
         "path-to-regexp": "^1.7.0"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "2.30.0",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "semver": "^5.4.1"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "3.2.1",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/node-preload": {
@@ -2528,25 +2252,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "4.1.2",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
-    "node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2732,31 +2437,25 @@
         "node": ">=6"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/open": {
-      "version": "7.4.2",
-      "license": "MIT",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
       "dependencies": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2935,44 +2634,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "6.1.3",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.21.0",
-        "npmlog": "^4.0.1",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/process-on-spawn": {
       "version": "1.0.0",
       "dev": true,
@@ -2984,26 +2645,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/psl": {
-      "version": "1.4.0",
-      "license": "MIT"
-    },
-    "node_modules/pump": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "dev": true,
@@ -3011,44 +2652,6 @@
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -3123,10 +2726,6 @@
       "version": "5.2.0",
       "license": "MIT"
     },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "license": "ISC"
-    },
     "node_modules/semver": {
       "version": "5.7.1",
       "license": "ISC",
@@ -3144,7 +2743,7 @@
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/shebang-command": {
@@ -3166,58 +2765,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/side-channel": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel/node_modules/object-inspect": {
-      "version": "1.10.3",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/signal-exit": {
       "version": "3.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/simple-get": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "decompress-response": "^4.2.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
     },
     "node_modules/sinon": {
       "version": "7.5.0",
@@ -3279,43 +2830,6 @@
         "npm": ">=6"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/string-width": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "dev": true,
@@ -3343,14 +2857,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "dev": true,
@@ -3360,45 +2866,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tar-stream/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/test-exclude": {
@@ -3432,10 +2899,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "license": "MIT"
     },
     "node_modules/ts-node": {
       "version": "9.1.1",
@@ -3472,6 +2935,7 @@
     },
     "node_modules/tslib": {
       "version": "1.10.0",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslint": {
@@ -3528,24 +2992,6 @@
         "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
       }
     },
-    "node_modules/tunnel": {
-      "version": "0.0.6",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "dev": true,
@@ -3582,35 +3028,11 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -3631,53 +3053,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.3",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
-    "node_modules/wide-align/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/string-width": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/workerpool": {
       "version": "6.2.0",
@@ -3753,7 +3128,7 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -3771,24 +3146,6 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/xml2js": {
-      "version": "0.4.23",
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
     },
     "node_modules/y18n": {
       "version": "4.0.1",
@@ -3908,119 +3265,139 @@
   "dependencies": {
     "@azure/abort-controller": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.4.tgz",
+      "integrity": "sha512-lNUmDRVGpanCsiUN3NWxFTdwmdFI53xwhkTFfHDGTYk46ca7Ind3nanJc+U6Zj9Tv+9nTCWRBscWEW1DyKOpTw==",
       "requires": {
         "tslib": "^2.0.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.0"
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
     "@azure/core-asynciterator-polyfill": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
+      "integrity": "sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg=="
     },
     "@azure/core-auth": {
-      "version": "1.3.0",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.3.2.tgz",
+      "integrity": "sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
-        "tslib": "^2.0.0"
+        "tslib": "^2.2.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.0"
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
-    "@azure/core-http": {
-      "version": "1.2.6",
+    "@azure/core-client": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.4.0.tgz",
+      "integrity": "sha512-6v1pn4ubNSeI56PUgj2NLR/nfoMfkjYmrtNX0YdXrjxSajKcf/TZc/QJtTFj4wHIvYqU/Yn/g/Zb+MNhFZ5c+Q==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-asynciterator-polyfill": "^1.0.0",
         "@azure/core-auth": "^1.3.0",
-        "@azure/core-tracing": "1.0.0-preview.11",
+        "@azure/core-rest-pipeline": "^1.4.0",
+        "@azure/core-tracing": "1.0.0-preview.13",
         "@azure/logger": "^1.0.0",
-        "@types/node-fetch": "^2.5.0",
-        "@types/tunnel": "^0.0.1",
-        "form-data": "^3.0.0",
-        "node-fetch": "^2.6.0",
-        "process": "^0.11.10",
-        "tough-cookie": "^4.0.0",
-        "tslib": "^2.2.0",
-        "tunnel": "^0.0.6",
-        "uuid": "^8.3.0",
-        "xml2js": "^0.4.19"
+        "tslib": "^2.2.0"
       },
       "dependencies": {
-        "form-data": {
-          "version": "3.0.1",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "tough-cookie": {
-          "version": "4.0.0",
-          "requires": {
-            "psl": "^1.1.33",
-            "punycode": "^2.1.1",
-            "universalify": "^0.1.2"
-          }
-        },
         "tslib": {
-          "version": "2.3.0"
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@azure/core-rest-pipeline": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.4.0.tgz",
+      "integrity": "sha512-M2uL9PbvhJIEMRoUad3EnXCHWLN/i0W7D7MQJ9rnIDW7iLVCteUiegdqNa2Cr1/7he/ysEXYiwaXiHmfack/6g==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-tracing": "1.0.0-preview.13",
+        "@azure/logger": "^1.0.0",
+        "form-data": "^4.0.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "tslib": "^2.2.0",
+        "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
     "@azure/core-tracing": {
-      "version": "1.0.0-preview.11",
+      "version": "1.0.0-preview.13",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
+      "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
       "requires": {
-        "@opencensus/web-types": "0.0.7",
-        "@opentelemetry/api": "1.0.0-rc.0",
+        "@opentelemetry/api": "^1.0.1",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@azure/core-util": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.0.0-beta.1.tgz",
+      "integrity": "sha512-pS6cup979/qyuyNP9chIybK2qVkJ3MarbY/bx3JcGKE6An6dRweLnsfJfU2ydqUI/B51Rjnn59ajHIhCUTwWZw==",
+      "requires": {
         "tslib": "^2.0.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.0"
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
     "@azure/identity": {
-      "version": "1.3.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-2.0.1.tgz",
+      "integrity": "sha512-gdGGuLKlKIQaf2RefA84keoBfmWfiAntbW2SzcdKvwLSGzsio/qkyY3sYUpXRz/sqLDxguuimgZukp7TPgwIlg==",
       "requires": {
-        "@azure/core-http": "^1.2.4",
-        "@azure/core-tracing": "1.0.0-preview.11",
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-client": "^1.0.0",
+        "@azure/core-rest-pipeline": "^1.1.0",
+        "@azure/core-tracing": "1.0.0-preview.13",
+        "@azure/core-util": "^1.0.0-beta.1",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-node": "1.0.0-beta.6",
+        "@azure/msal-browser": "^2.16.0",
+        "@azure/msal-common": "^4.5.1",
+        "@azure/msal-node": "^1.3.0",
         "@types/stoppable": "^1.1.0",
-        "axios": "^0.21.1",
         "events": "^3.0.0",
         "jws": "^4.0.0",
-        "keytar": "^7.3.0",
-        "msal": "^1.0.2",
-        "open": "^7.0.0",
-        "qs": "^6.7.0",
+        "open": "^8.0.0",
         "stoppable": "^1.1.0",
-        "tslib": "^2.0.0",
+        "tslib": "^2.2.0",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "@azure/msal-node": {
-          "version": "1.0.0-beta.6",
-          "requires": {
-            "@azure/msal-common": "^4.0.0",
-            "axios": "^0.21.1",
-            "jsonwebtoken": "^8.5.1",
-            "uuid": "^8.3.0"
-          }
-        },
-        "axios": {
-          "version": "0.21.4",
-          "requires": {
-            "follow-redirects": "^1.14.0"
-          }
-        },
         "jwa": {
           "version": "2.0.0",
           "requires": {
@@ -4036,30 +3413,48 @@
             "safe-buffer": "^5.0.1"
           }
         },
-        "qs": {
-          "version": "6.10.1",
-          "requires": {
-            "side-channel": "^1.0.4"
-          }
-        },
         "tslib": {
           "version": "2.3.0"
         }
       }
     },
     "@azure/logger": {
-      "version": "1.0.2",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
+      "integrity": "sha512-aK4s3Xxjrx3daZr3VylxejK3vG5ExXck5WOHDJ8in/k9AqlfIyFMMT1uG7u8mNjX+QRILTIn0/Xgschfh/dQ9g==",
       "requires": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.2.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.0"
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@azure/msal-browser": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.21.0.tgz",
+      "integrity": "sha512-y+oAUJJ0m7gRUT505iGT4SDXktrRzOE3HZC0+nQyHDI+3O7BKK5NjQUwD/4V8FNNyrhxEtLk99iwJEo61epinQ==",
+      "requires": {
+        "@azure/msal-common": "^6.0.0"
+      },
+      "dependencies": {
+        "@azure/msal-common": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.0.0.tgz",
+          "integrity": "sha512-Vva3snqmWPHJNDCBb4lz3D0rvZsi/0QikAxHvVFNwtNg5pP4NZE4U34tNiXN+m9KhlQFrZBPkE5rk7dIEOGcWw==",
+          "requires": {
+            "debug": "^4.1.1"
+          }
         }
       }
     },
     "@azure/msal-common": {
-      "version": "4.3.0",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-4.5.1.tgz",
+      "integrity": "sha512-/i5dXM+QAtO+6atYd5oHGBAx48EGSISkXNXViheliOQe+SIFMDo3gSq3lL54W0suOSAsVPws3XnTaIHlla0PIQ==",
       "requires": {
         "debug": "^4.1.1"
       }
@@ -4327,11 +3722,10 @@
       "version": "0.1.3",
       "dev": true
     },
-    "@opencensus/web-types": {
-      "version": "0.0.7"
-    },
     "@opentelemetry/api": {
-      "version": "1.0.0-rc.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
+      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ=="
     },
     "@sinonjs/commons": {
       "version": "1.6.0",
@@ -4361,6 +3755,11 @@
       "version": "0.7.1",
       "dev": true
     },
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+    },
     "@types/mocha": {
       "version": "8.2.0",
       "dev": true
@@ -4368,20 +3767,8 @@
     "@types/node": {
       "version": "14.14.13"
     },
-    "@types/node-fetch": {
-      "version": "2.5.4",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/stoppable": {
       "version": "1.1.1",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/tunnel": {
-      "version": "0.0.1",
       "requires": {
         "@types/node": "*"
       }
@@ -4392,6 +3779,14 @@
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "dev": true
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -4404,10 +3799,6 @@
     "ansi-colors": {
       "version": "4.1.1",
       "dev": true
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "optional": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -4431,21 +3822,9 @@
         "default-require-extensions": "^3.0.0"
       }
     },
-    "aproba": {
-      "version": "1.2.0",
-      "optional": true
-    },
     "archy": {
       "version": "1.0.0",
       "dev": true
-    },
-    "are-we-there-yet": {
-      "version": "1.1.5",
-      "optional": true,
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
     },
     "arg": {
       "version": "4.1.3",
@@ -4463,7 +3842,9 @@
       "dev": true
     },
     "asynckit": {
-      "version": "0.4.0"
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "axios": {
       "version": "0.24.0",
@@ -4475,33 +3856,9 @@
       "version": "1.0.0",
       "dev": true
     },
-    "base64-js": {
-      "version": "1.5.1",
-      "optional": true
-    },
     "binary-extensions": {
       "version": "2.2.0",
       "dev": true
-    },
-    "bl": {
-      "version": "4.1.0",
-      "optional": true,
-      "requires": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "optional": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -4533,14 +3890,6 @@
         "picocolors": "^1.0.0"
       }
     },
-    "buffer": {
-      "version": "5.7.1",
-      "optional": true,
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "buffer-equal-constant-time": {
       "version": "1.0.1"
     },
@@ -4560,13 +3909,6 @@
         "make-dir": "^3.0.0",
         "package-hash": "^4.0.0",
         "write-file-atomic": "^3.0.0"
-      }
-    },
-    "call-bind": {
-      "version": "1.0.2",
-      "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
       }
     },
     "camelcase": {
@@ -4604,10 +3946,6 @@
         "readdirp": "~3.6.0"
       }
     },
-    "chownr": {
-      "version": "1.1.4",
-      "optional": true
-    },
     "clean-stack": {
       "version": "2.2.0",
       "dev": true
@@ -4636,10 +3974,6 @@
         }
       }
     },
-    "code-point-at": {
-      "version": "1.1.0",
-      "optional": true
-    },
     "color-convert": {
       "version": "1.9.3",
       "dev": true,
@@ -4653,6 +3987,8 @@
     },
     "combined-stream": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -4669,10 +4005,6 @@
       "version": "0.0.1",
       "dev": true
     },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "optional": true
-    },
     "convert-source-map": {
       "version": "1.8.0",
       "dev": true,
@@ -4685,10 +4017,6 @@
           "dev": true
         }
       }
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "optional": true
     },
     "create-require": {
       "version": "1.1.1",
@@ -4717,17 +4045,6 @@
       "version": "1.2.0",
       "dev": true
     },
-    "decompress-response": {
-      "version": "4.2.1",
-      "optional": true,
-      "requires": {
-        "mimic-response": "^2.0.0"
-      }
-    },
-    "deep-extend": {
-      "version": "0.6.0",
-      "optional": true
-    },
     "default-require-extensions": {
       "version": "3.0.0",
       "dev": true,
@@ -4735,16 +4052,15 @@
         "strip-bom": "^4.0.0"
       }
     },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
+    },
     "delayed-stream": {
-      "version": "1.0.0"
-    },
-    "delegates": {
       "version": "1.0.0",
-      "optional": true
-    },
-    "detect-libc": {
-      "version": "1.0.3",
-      "optional": true
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "diff": {
       "version": "3.5.0",
@@ -4764,13 +4080,6 @@
       "version": "8.0.0",
       "dev": true
     },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "optional": true,
-      "requires": {
-        "once": "^1.4.0"
-      }
-    },
     "es6-error": {
       "version": "4.1.1",
       "dev": true
@@ -4789,10 +4098,6 @@
     },
     "events": {
       "version": "3.3.0"
-    },
-    "expand-template": {
-      "version": "2.0.3",
-      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -4833,43 +4138,27 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fromentries": {
       "version": "1.3.2",
       "dev": true
-    },
-    "fs-constants": {
-      "version": "1.0.0",
-      "optional": true
     },
     "fs.realpath": {
       "version": "1.0.0",
       "dev": true
     },
     "function-bind": {
-      "version": "1.1.1"
-    },
-    "gauge": {
-      "version": "2.7.4",
-      "optional": true,
-      "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      },
-      "dependencies": {
-        "strip-ansi": {
-          "version": "3.0.1",
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
-      }
+      "version": "1.1.1",
+      "dev": true
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -4879,21 +4168,9 @@
       "version": "2.0.5",
       "dev": true
     },
-    "get-intrinsic": {
-      "version": "1.1.1",
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
-      }
-    },
     "get-package-type": {
       "version": "0.1.0",
       "dev": true
-    },
-    "github-from-package": {
-      "version": "0.0.0",
-      "optional": true
     },
     "glob": {
       "version": "7.2.0",
@@ -4928,6 +4205,7 @@
     },
     "has": {
       "version": "1.0.3",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -4935,13 +4213,6 @@
     "has-flag": {
       "version": "3.0.0",
       "dev": true
-    },
-    "has-symbols": {
-      "version": "1.0.1"
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "optional": true
     },
     "hasha": {
       "version": "5.2.2",
@@ -4959,9 +4230,24 @@
       "version": "2.0.2",
       "dev": true
     },
-    "ieee754": {
-      "version": "1.2.1",
-      "optional": true
+    "http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "requires": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -4981,11 +4267,7 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "devOptional": true
-    },
-    "ini": {
-      "version": "1.3.8",
-      "optional": true
+      "dev": true
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -5002,18 +4284,13 @@
       }
     },
     "is-docker": {
-      "version": "2.2.1"
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
     },
     "is-extglob": {
       "version": "2.1.1",
       "dev": true
-    },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "optional": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
     },
     "is-glob": {
       "version": "4.0.3",
@@ -5048,6 +4325,8 @@
     },
     "is-wsl": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -5202,14 +4481,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "keytar": {
-      "version": "7.7.0",
-      "optional": true,
-      "requires": {
-        "node-addon-api": "^3.0.0",
-        "prebuild-install": "^6.0.0"
-      }
-    },
     "locate-path": {
       "version": "6.0.0",
       "dev": true,
@@ -5330,17 +4601,17 @@
       }
     },
     "mime-db": {
-      "version": "1.42.0"
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
     },
     "mime-types": {
-      "version": "2.1.25",
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
       "requires": {
-        "mime-db": "1.42.0"
+        "mime-db": "1.51.0"
       }
-    },
-    "mimic-response": {
-      "version": "2.1.0",
-      "optional": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -5351,7 +4622,7 @@
     },
     "minimist": {
       "version": "1.2.5",
-      "devOptional": true
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.5",
@@ -5359,10 +4630,6 @@
       "requires": {
         "minimist": "^1.2.5"
       }
-    },
-    "mkdirp-classic": {
-      "version": "0.5.3",
-      "optional": true
     },
     "mocha": {
       "version": "9.2.0",
@@ -5464,19 +4731,9 @@
     "ms": {
       "version": "2.1.2"
     },
-    "msal": {
-      "version": "1.4.11",
-      "requires": {
-        "tslib": "^1.9.3"
-      }
-    },
     "nanoid": {
       "version": "3.2.0",
       "dev": true
-    },
-    "napi-build-utils": {
-      "version": "1.0.2",
-      "optional": true
     },
     "nise": {
       "version": "1.5.2",
@@ -5487,23 +4744,6 @@
         "just-extend": "^4.0.2",
         "lolex": "^4.1.0",
         "path-to-regexp": "^1.7.0"
-      }
-    },
-    "node-abi": {
-      "version": "2.30.0",
-      "optional": true,
-      "requires": {
-        "semver": "^5.4.1"
-      }
-    },
-    "node-addon-api": {
-      "version": "3.2.1",
-      "optional": true
-    },
-    "node-fetch": {
-      "version": "2.6.7",
-      "requires": {
-        "whatwg-url": "^5.0.0"
       }
     },
     "node-preload": {
@@ -5520,20 +4760,6 @@
     "normalize-path": {
       "version": "3.0.0",
       "dev": true
-    },
-    "npmlog": {
-      "version": "4.1.2",
-      "optional": true,
-      "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "optional": true
     },
     "nyc": {
       "version": "15.1.0",
@@ -5666,22 +4892,21 @@
         }
       }
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "optional": true
-    },
     "once": {
       "version": "1.4.0",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
     },
     "open": {
-      "version": "7.4.2",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
       "requires": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
       }
     },
     "p-limit": {
@@ -5790,32 +5015,6 @@
         }
       }
     },
-    "prebuild-install": {
-      "version": "6.1.3",
-      "optional": true,
-      "requires": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.21.0",
-        "npmlog": "^4.0.1",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      }
-    },
-    "process": {
-      "version": "0.11.10"
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "optional": true
-    },
     "process-on-spawn": {
       "version": "1.0.0",
       "dev": true,
@@ -5823,58 +5022,11 @@
         "fromentries": "^1.2.0"
       }
     },
-    "psl": {
-      "version": "1.4.0"
-    },
-    "pump": {
-      "version": "3.0.0",
-      "optional": true,
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "punycode": {
-      "version": "2.1.1"
-    },
     "randombytes": {
       "version": "2.1.0",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "rc": {
-      "version": "1.2.8",
-      "optional": true,
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.7",
-      "optional": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "optional": true
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "optional": true
-        }
       }
     },
     "readdirp": {
@@ -5921,9 +5073,6 @@
     "safe-buffer": {
       "version": "5.2.0"
     },
-    "sax": {
-      "version": "1.2.4"
-    },
     "semver": {
       "version": "5.7.1"
     },
@@ -5936,7 +5085,7 @@
     },
     "set-blocking": {
       "version": "2.0.0",
-      "devOptional": true
+      "dev": true
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -5949,35 +5098,9 @@
       "version": "3.0.0",
       "dev": true
     },
-    "side-channel": {
-      "version": "1.0.4",
-      "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      },
-      "dependencies": {
-        "object-inspect": {
-          "version": "1.10.3"
-        }
-      }
-    },
     "signal-exit": {
       "version": "3.0.3",
-      "devOptional": true
-    },
-    "simple-concat": {
-      "version": "1.0.1",
-      "optional": true
-    },
-    "simple-get": {
-      "version": "3.1.0",
-      "optional": true,
-      "requires": {
-        "decompress-response": "^4.2.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
+      "dev": true
     },
     "sinon": {
       "version": "7.5.0",
@@ -6023,37 +5146,6 @@
     "stoppable": {
       "version": "1.1.0"
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "optional": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "optional": true
-        }
-      }
-    },
-    "string-width": {
-      "version": "1.0.2",
-      "optional": true,
-      "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "dependencies": {
-        "strip-ansi": {
-          "version": "3.0.1",
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
-      }
-    },
     "strip-ansi": {
       "version": "6.0.1",
       "dev": true,
@@ -6071,47 +5163,11 @@
       "version": "4.0.0",
       "dev": true
     },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "optional": true
-    },
     "supports-color": {
       "version": "5.5.0",
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
-      }
-    },
-    "tar-fs": {
-      "version": "2.1.1",
-      "optional": true,
-      "requires": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "tar-stream": {
-      "version": "2.2.0",
-      "optional": true,
-      "requires": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "optional": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "test-exclude": {
@@ -6134,9 +5190,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tr46": {
-      "version": "0.0.3"
-    },
     "ts-node": {
       "version": "9.1.1",
       "dev": true,
@@ -6156,7 +5209,8 @@
       }
     },
     "tslib": {
-      "version": "1.10.0"
+      "version": "1.10.0",
+      "dev": true
     },
     "tslint": {
       "version": "6.1.3",
@@ -6194,16 +5248,6 @@
         "tslib": "^1.8.1"
       }
     },
-    "tunnel": {
-      "version": "0.0.6"
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "optional": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "type-detect": {
       "version": "4.0.8",
       "dev": true
@@ -6223,25 +5267,8 @@
       "version": "4.1.3",
       "dev": true
     },
-    "universalify": {
-      "version": "0.1.2"
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "optional": true
-    },
     "uuid": {
       "version": "8.3.2"
-    },
-    "webidl-conversions": {
-      "version": "3.0.1"
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "which": {
       "version": "2.0.2",
@@ -6253,38 +5280,6 @@
     "which-module": {
       "version": "2.0.0",
       "dev": true
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "optional": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "optional": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "optional": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
     },
     "workerpool": {
       "version": "6.2.0",
@@ -6334,7 +5329,7 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "devOptional": true
+      "dev": true
     },
     "write-file-atomic": {
       "version": "3.0.3",
@@ -6349,16 +5344,6 @@
     "xml": {
       "version": "1.0.1",
       "dev": true
-    },
-    "xml2js": {
-      "version": "0.4.23",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "11.0.1"
     },
     "y18n": {
       "version": "4.0.1",

--- a/azure-kusto-data/package.json
+++ b/azure-kusto-data/package.json
@@ -34,7 +34,7 @@
   "license": "ISC",
   "homepage": "https://github.com/Azure/azure-kusto-node/blob/master/azure-kusto-data/README.md",
   "dependencies": {
-    "@azure/identity": "^1.3.0",
+    "@azure/identity": "^2.0.1",
     "@azure/msal-node": "^1.5.0",
     "@types/node": "^14.14.13",
     "@types/uuid": "^8.3.0",

--- a/azure-kusto-data/source/tokenProvider.ts
+++ b/azure-kusto-data/source/tokenProvider.ts
@@ -84,10 +84,7 @@ export class MsiTokenProvider extends TokenProviderBase {
             this.managedIdentityCredential = this.clientId  ? new ManagedIdentityCredential(this.clientId) : new ManagedIdentityCredential();
         }
         const msiToken = await this.managedIdentityCredential.getToken(this.kustoUri);
-        if (msiToken?.token != null) {
-            return { tokenType: BEARER_TYPE, accessToken: msiToken.token };
-        }
-        throw new Error(`"Failed to obtain MSI token for '${this.kustoUri}' with '${this.clientId}'`)
+        return { tokenType: BEARER_TYPE, accessToken: msiToken.token };
     }
 }
 
@@ -106,11 +103,7 @@ export class AzCliTokenProvider extends TokenProviderBase {
             this.azureCliCredentials = new AzureCliCredential();
         }
         const response = await this.azureCliCredentials.getToken(this.scopes);
-
-        if(response){
-            return { tokenType: BEARER_TYPE, accessToken: response.token };
-        }
-        throw new Error(`"Failed to obtain AzCli token for '${this.kustoUri}'`)
+        return { tokenType: BEARER_TYPE, accessToken: response.token };
     }
 }
 


### PR DESCRIPTION
Az identity 1.x uses an old version of simple-get which is now insecure - https://github.com/Azure/azure-kusto-node/security/dependabot/azure-kusto-data/package-lock.json/simple-get/open.
So this PR updates the package.

-Remove null checks for az identity, as per the migration doc -https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/migration-v1-v2.md

