### PR TITLE
Remove cache control from meta data endpoint

### DIFF
--- a/packages/azure-kusto-data/src/cloudSettings.ts
+++ b/packages/azure-kusto-data/src/cloudSettings.ts
@@ -41,8 +41,8 @@ export class CloudSettings {
         try {
             const response = await axios.get<{ AzureAD: CloudInfo | undefined }>(kustoUri + this.METADATA_ENDPOINT, {
                 headers: {
-                    'Cache-Control': 'no-cache',
-                }
+                    "Cache-Control": "no-cache",
+                },
             });
             if (response.status === 200) {
                 this.cloudCache[kustoUri] = response.data.AzureAD || this.defaultCloudInfo;

--- a/packages/azure-kusto-data/src/cloudSettings.ts
+++ b/packages/azure-kusto-data/src/cloudSettings.ts
@@ -42,6 +42,14 @@ export class CloudSettings {
             const response = await axios.get<{ AzureAD: CloudInfo | undefined }>(kustoUri + this.METADATA_ENDPOINT, {
                 headers: {
                     "Cache-Control": "no-cache",
+                    // Disable caching - it's being cached in memory (Service returns max-age).
+                    // The original motivation for this is due to a CORS issue in Ibiza due to a dynamic subdomain.
+                    // The first dynamic subdomain is attached to the cache and for some reason isn't invalidated
+                    // when there is a new subdomain. It causes the request failure due to CORS.
+                    // Example:
+                    // Access to XMLHttpRequest at 'https://safrankecc.canadacentral.kusto.windows.net/v1/rest/auth/metadata' from origin
+                    // 'https://sandbox-46-11.reactblade.portal.azure.net' has been blocked by CORS policy: The 'Access-Control-Allow-Origin' header has a value
+                    // 'https://sandbox-46-10.reactblade.portal.azure.net' that is not equal to the supplied origin.
                 },
             });
             if (response.status === 200) {

--- a/packages/azure-kusto-data/src/cloudSettings.ts
+++ b/packages/azure-kusto-data/src/cloudSettings.ts
@@ -39,7 +39,11 @@ export class CloudSettings {
         }
 
         try {
-            const response = await axios.get<{ AzureAD: CloudInfo | undefined }>(kustoUri + this.METADATA_ENDPOINT);
+            const response = await axios.get<{ AzureAD: CloudInfo | undefined }>(kustoUri + this.METADATA_ENDPOINT, {
+                headers: {
+                    'Cache-Control': 'no-cache',
+                }
+            });
             if (response.status === 200) {
                 this.cloudCache[kustoUri] = response.data.AzureAD || this.defaultCloudInfo;
             } else {


### PR DESCRIPTION
#### Pull Request Description

Set cache control to 'no-cache' for .auth/metadata endpoint.
This causes issues since the server returns the header with max-age which causes the server to cache,
Then it fails due to a CORS issue when making the request from a different sub domain that was not allowed by the response that was cached.

---
