### PR TITLE
Fix errors - ascii in header names, authorization in errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -148,7 +148,7 @@ module.exports = {
         "no-cond-assign": "error",
         "no-console": "error",
         "no-const-assign": "error",
-        "no-control-regex": "error",
+        "no-control-regex": "off",
         "no-debugger": "error",
         "no-delete-var": "error",
         "no-dupe-args": "error",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Remove authorization header from errors
-- Escape non-ascii headers to align with the service
+-   Remove authorization header from errors
+-   Escape non-ascii headers to align with the service
 
 ## [5.0.2] - 2023-03-20
 
 ### Added
 
-- Internal devops improvements
+-   Internal devops improvements
 
 ## [5.0.1] - 2023-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Remove authorization header from errors
+- Escape non-ascii headers to align with the service
+
 ## [5.0.2] - 2023-03-20
 
 ### Added
 
--   Internal devops improvements
+- Internal devops improvements
 
 ## [5.0.1] - 2023-02-23
 

--- a/packages/azure-kusto-data/src/client.ts
+++ b/packages/azure-kusto-data/src/client.ts
@@ -221,7 +221,7 @@ export class KustoClient {
                 // Since it's impossible to modify the error request object, the only way to censor the Authorization header is to remove it.
                 error.request = undefined;
                 if (error?.config?.headers) {
-                    error.config.headers["Authorization"] = "<REDACTED>";
+                    error.config.headers.Authorization = "<REDACTED>";
                 }
                 if (error.response && error.response.status === 429) {
                     throw new ThrottlingError("POST request failed with status 429 (Too Many Requests)", error);

--- a/packages/azure-kusto-ingest/test/e2eTests/e2eTest.ts
+++ b/packages/azure-kusto-ingest/test/e2eTests/e2eTest.ts
@@ -34,7 +34,7 @@ const main = (): void => {
     }
 
     const engineKcsb = ConnectionStringBuilder.withAadApplicationKeyAuthentication(process.env.ENGINE_CONNECTION_STRING ?? "", appId, appKey, tenantId);
-    engineKcsb.applicationNameForTracing = "NodeE2ETest";
+    engineKcsb.applicationNameForTracing = "NodeE2ETest_ø";
 
     const queryClient = new Client(engineKcsb);
     const streamingIngestClient = new StreamingIngestClient(engineKcsb);
@@ -322,6 +322,9 @@ const main = (): void => {
                 try {
                     await queryClient.executeQuery(databaseName, "invalidSyntax ");
                 } catch (ex) {
+                    const exTyped = ex as { request: unknown; config: { headers: { [k: string]: string } } };
+                    assert.strictEqual(exTyped.request, undefined);
+                    assert.strictEqual(exTyped.config.headers["Authorization"], "<REDACTED>");
                     return;
                 }
                 assert.fail(`General BadRequest`);

--- a/packages/azure-kusto-ingest/test/e2eTests/e2eTest.ts
+++ b/packages/azure-kusto-ingest/test/e2eTests/e2eTest.ts
@@ -324,7 +324,7 @@ const main = (): void => {
                 } catch (ex) {
                     const exTyped = ex as { request: unknown; config: { headers: { [k: string]: string } } };
                     assert.strictEqual(exTyped.request, undefined);
-                    assert.strictEqual(exTyped.config.headers["Authorization"], "<REDACTED>");
+                    assert.strictEqual(exTyped.config.headers.Authorization, "<REDACTED>");
                     return;
                 }
                 assert.fail(`General BadRequest`);


### PR DESCRIPTION
### Fixed

- Remove authorization header from errors
- Escape non-ascii headers to align with the service