### PR TITLE
Fix headers v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [6.0.2] - 2024-04-11
+### Changed
+- Take `process.argv[1]` as an app identifier instead of `process.title`
+- More strict header escaping, limit the length to 100 characters per field
 
 ## [6.0.1] - 2024-04-07
 
 ### Fixed
-
--   Version number fix
+- Version number fix
 
 ## [6.0.0] - 2024-04-07
 

--- a/packages/azure-kusto-data/src/clientDetails.ts
+++ b/packages/azure-kusto-data/src/clientDetails.ts
@@ -15,7 +15,7 @@ declare namespace NodeJS {
 }
 
 // This regex allows all printable ascii, except spaces and chars we use in the format
-const ReplaceRegex = /[^\x21-\x7A]+/g;
+const ReplaceRegex = /[^\w.\-()]/g;
 const None = "[none]";
 
 export class ClientDetails {
@@ -33,7 +33,7 @@ export class ClientDetails {
 
     static defaultApplication(): string {
         if (isNode) {
-            return process?.env?.npm_package_name || process.title || None;
+            return process?.env?.npm_package_name || process?.argv[1] || None;
         } else {
             return window?.location?.href || None;
         }
@@ -67,7 +67,7 @@ export class ClientDetails {
     }
 
     static escapeHeader(header: string, wrapInBrackets: boolean = true): string {
-        const clean = header.replace(ReplaceRegex, "_");
+        const clean = header.substring(0, 100).replace(ReplaceRegex, "_");
         return wrapInBrackets ? `{${clean}}` : clean;
     }
 

--- a/packages/azure-kusto-data/test/headersTest.ts
+++ b/packages/azure-kusto-data/test/headersTest.ts
@@ -53,10 +53,10 @@ describe("Test Headers", () => {
     });
 
     it.concurrent("Should remove unwanted characters", () => {
-        const clientDetails = ClientDetails.setConnectorDetails("Café", "1 . 0", "my|test{}app", "1.0", true, null, null);
+        const clientDetails = ClientDetails.setConnectorDetails("Café", "1 . 0", "my|test\\{}\\app", new Array(1024).join("s"), true, null, null);
         const headers = clientDetails.getHeaders();
         assert.strictEqual(headers["x-ms-client-version"]?.startsWith("Kusto.JavaScript.Client:"), true);
-        assert.strictEqual(headers["x-ms-app"], "Kusto.Caf_:{1_._0}|App.{my_test_app}:{1.0}");
+        assert.strictEqual(headers["x-ms-app"], "Kusto.Caf_:{1_._0}|App.{my_test____app}:{ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss}");
         assert.notStrictEqual(headers["x-ms-user"], "[none]");
     });
 });


### PR DESCRIPTION
### Changed
- Take `process.argv[1]` as an app identifier instead of `process.title`
- More strict header escaping, limit the length to 100 characters per field
