### PR TITLE
Auth metadata endpoint is always rooted.

### DIFF
--- a/packages/azure-kusto-data/src/cloudSettings.ts
+++ b/packages/azure-kusto-data/src/cloudSettings.ts
@@ -18,7 +18,7 @@ const AXIOS_ERR_NETWORK = axios?.AxiosError?.ERR_NETWORK ?? "ERR_NETWORK";
  * This class holds data for all cloud instances, and returns the specific data instance by parsing the dns suffix from a URL
  */
 class CloudSettings {
-    static METADATA_ENDPOINT = "/v1/rest/auth/metadata";
+    METADATA_ENDPOINT = "/v1/rest/auth/metadata";
     defaultCloudInfo: CloudInfo = {
         LoginEndpoint: process?.env?.AadAuthorityUri || "https://login.microsoftonline.com",
         LoginMfaRequired: false,
@@ -44,7 +44,7 @@ class CloudSettings {
         }
 
         try {
-            const response = await axios.get<{ AzureAD: CloudInfo | undefined }>(CloudSettings.getAuthMetadataEndpointFromClusterUri(kustoUri), {
+            const response = await axios.get<{ AzureAD: CloudInfo | undefined }>(this.getAuthMetadataEndpointFromClusterUri(kustoUri), {
                 headers: {
                     "Cache-Control": "no-cache",
                     // Disable caching - it's being cached in memory (Service returns max-age).
@@ -86,10 +86,10 @@ class CloudSettings {
         return urlString;
     }
 
-    static getAuthMetadataEndpointFromClusterUri(kustoUri: string): string {
+    getAuthMetadataEndpointFromClusterUri(kustoUri: string): string {
         const url = new URL(kustoUri);
         // Returns endpoint URL in the form of https://<cluster>:port/v1/rest/auth/metadata
-        return `${url.protocol}//${url.host}${CloudSettings.METADATA_ENDPOINT}`;
+        return `${url.protocol}//${url.host}${this.METADATA_ENDPOINT}`;
     }
 
     static getAuthorityUri(cloudInfo: CloudInfo, authorityId?: string): string {

--- a/packages/azure-kusto-data/src/cloudSettings.ts
+++ b/packages/azure-kusto-data/src/cloudSettings.ts
@@ -18,7 +18,7 @@ const AXIOS_ERR_NETWORK = axios?.AxiosError?.ERR_NETWORK ?? "ERR_NETWORK";
  * This class holds data for all cloud instances, and returns the specific data instance by parsing the dns suffix from a URL
  */
 class CloudSettings {
-    METADATA_ENDPOINT = "/v1/rest/auth/metadata";
+    static METADATA_ENDPOINT = "/v1/rest/auth/metadata";
     defaultCloudInfo: CloudInfo = {
         LoginEndpoint: process?.env?.AadAuthorityUri || "https://login.microsoftonline.com",
         LoginMfaRequired: false,
@@ -44,7 +44,7 @@ class CloudSettings {
         }
 
         try {
-            const response = await axios.get<{ AzureAD: CloudInfo | undefined }>(kustoUri + this.METADATA_ENDPOINT, {
+            const response = await axios.get<{ AzureAD: CloudInfo | undefined }>(CloudSettings.getAuthMetadataEndpointFromClusterUri(kustoUri), {
                 headers: {
                     "Cache-Control": "no-cache",
                     // Disable caching - it's being cached in memory (Service returns max-age).
@@ -84,6 +84,12 @@ class CloudSettings {
             return urlString.slice(0, urlString.length - 1);
         }
         return urlString;
+    }
+
+    static getAuthMetadataEndpointFromClusterUri(kustoUri: string): string {
+        const url = new URL(kustoUri);
+        // Returns endpoint URL in the form of https://<cluster>:port/v1/rest/auth/metadata
+        return `${url.protocol}//${url.host}${CloudSettings.METADATA_ENDPOINT}`;
     }
 
     static getAuthorityUri(cloudInfo: CloudInfo, authorityId?: string): string {

--- a/packages/azure-kusto-data/test/cloudSettingsTest.ts
+++ b/packages/azure-kusto-data/test/cloudSettingsTest.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import assert from "assert";
+
+import { CloudSettings } from "../src/cloudSettings.js";
+
+describe("CloudSettings.getAuthMetadataEndpointFromClusterUri", () => {
+    it("valid input", () => {
+        assert.strictEqual(
+            CloudSettings.getAuthMetadataEndpointFromClusterUri("https://statusreturner.azurewebsites.net/"),
+            "https://statusreturner.azurewebsites.net/v1/rest/auth/metadata"
+        );
+
+        // With path
+        assert.strictEqual(
+            CloudSettings.getAuthMetadataEndpointFromClusterUri("https://statusreturner.azurewebsites.net/test/test2/test"),
+            "https://statusreturner.azurewebsites.net/v1/rest/auth/metadata"
+        );
+
+        // With non-default port
+        assert.strictEqual(
+            CloudSettings.getAuthMetadataEndpointFromClusterUri("https://statusreturner.azurewebsites.net:5050/"),
+            "https://statusreturner.azurewebsites.net:5050/v1/rest/auth/metadata"
+        );
+
+        // With leading slash
+        assert.strictEqual(
+            CloudSettings.getAuthMetadataEndpointFromClusterUri("https://statusreturner.azurewebsites.net//////"),
+            "https://statusreturner.azurewebsites.net/v1/rest/auth/metadata"
+        );
+    });
+});

--- a/packages/azure-kusto-ingest/test/e2eTests/e2eTest.ts
+++ b/packages/azure-kusto-ingest/test/e2eTests/e2eTest.ts
@@ -449,6 +449,8 @@ const main = (): void => {
             }
         });
 
+        /*
+        // This test relies on the URI path part which we now ignore when retrieving the auth metadata
         it.concurrent.each(redirectCodes.map((r) => ({ code: r })))("noRedirectsCloudFail_%s", async ({ code }) => {
             const kcsb = ConnectionStringBuilder.withAadApplicationKeyAuthentication(
                 `https://statusreturner.azurewebsites.net/nocloud/${code}`,
@@ -467,6 +469,7 @@ const main = (): void => {
                 client.close();
             }
         });
+        */
     });
 
     describe("Mgmt Parsing", () => {


### PR DESCRIPTION
### Changed
Auth metadata endpoint is always relative to the cluster URI

