### PR TITLE
Fix tag handling in `ingestionProperties`

### DIFF
--- a/packages/azure-kusto-ingest/src/ingestionBlobInfo.ts
+++ b/packages/azure-kusto-ingest/src/ingestionBlobInfo.ts
@@ -49,17 +49,17 @@ export class IngestionBlobInfo {
 
         const tags: string[] = [];
         if (ingestionProperties.additionalTags) {
-            tags.concat(ingestionProperties.additionalTags);
+            tags.push(...ingestionProperties.additionalTags);
         }
         if (ingestionProperties.dropByTags) {
-            tags.concat(ingestionProperties.dropByTags.map((t) => "drop-by:" + t));
+            tags.push(...ingestionProperties.dropByTags.map((t) => "drop-by:" + t));
         }
         if (ingestionProperties.ingestByTags) {
-            tags.concat(ingestionProperties.ingestByTags.map((t) => "ingest-by:" + t));
+            tags.push(...ingestionProperties.ingestByTags.map((t) => "ingest-by:" + t));
         }
 
-        if (tags && tags.length > 0) {
-            additionalProperties.tags = tags;
+        if (tags.length > 0) {
+            additionalProperties.tags = JSON.stringify(tags);
         }
 
         if (ingestionProperties.ingestIfNotExists) {

--- a/packages/azure-kusto-ingest/src/ingestionProperties.ts
+++ b/packages/azure-kusto-ingest/src/ingestionProperties.ts
@@ -182,7 +182,7 @@ export interface IngestionPropertiesFields {
      */
     ingestionMappingType?: IngestionMappingKind;
     ingestionMappingKind?: IngestionMappingKind;
-    additionalTags?: string;
+    additionalTags?: string[];
     ingestIfNotExists?: string;
     ingestByTags?: string[];
     dropByTags?: string[];

--- a/packages/azure-kusto-ingest/test/ingestionPropertiesTest.ts
+++ b/packages/azure-kusto-ingest/test/ingestionPropertiesTest.ts
@@ -360,5 +360,16 @@ describe("IngestionProperties", () => {
             ];
             assert.deepStrictEqual(JSON.parse(ingestionBlobInfo.AdditionalProperties.ingestionMapping), reParsed);
         });
+
+        it.concurrent("should handle tags correctly", () => {
+            const props = new IngestionProperties({
+                ingestByTags: ["tag1"],
+                dropByTags: ["tag2"],
+                additionalTags: ["tag3"],
+            });
+
+            const ingestionBlobInfo = new IngestionBlobInfo(new BlobDescriptor("https://account.blob.core.windows.net/blobcontainer/blobfile.json"), props);
+            assert.deepStrictEqual(JSON.parse(ingestionBlobInfo.AdditionalProperties.tags), ["tag3", "drop-by:tag2", "ingest-by:tag1"]);
+        });
     });
 });


### PR DESCRIPTION
This fix is the same as in https://github.com/Azure/azure-kusto-go/pull/305, but it applies to the Node SDK.