### PR TITLE
chore: bump version to 7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.0] - 2026-05-12
+
+### Security
+
+- Upgraded axios from 1.4.0 to ^1.16.0, fixing CVE-2024-39338, CVE-2025-27152, CVE-2025-58754, CVE-2026-42033, CVE-2026-42035, CVE-2026-42043, CVE-2026-42264
+- Bumped transitive MSAL dependencies to latest within semver range (msal-node 5.2.1, msal-browser 5.10.1, msal-common 16.6.1)
+
 ## [7.1.0] - 2026-03-31
 
 ### Fixed

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "version": "7.1.0",
+  "version": "7.2.0",
   "useNx": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19285,7 +19285,7 @@
             }
         },
         "packages/azure-kusto-data": {
-            "version": "7.1.0",
+            "version": "7.2.0",
             "license": "ISC",
             "dependencies": {
                 "@azure/core-auth": "^1.10.0",
@@ -19307,7 +19307,7 @@
             }
         },
         "packages/azure-kusto-ingest": {
-            "version": "7.1.0",
+            "version": "7.2.0",
             "license": "ISC",
             "dependencies": {
                 "@azure/core-util": "^1.13.1",
@@ -19321,7 +19321,7 @@
                 "@types/tmp": "^0.2.6",
                 "@types/uuid": "^8.3.4",
                 "@types/uuid-validate": "0.0.1",
-                "azure-kusto-data": "^7.1.0",
+                "azure-kusto-data": "^7.2.0",
                 "browserify-zlib": "0.2.0",
                 "buffer": "^6.0.3",
                 "is-ip": "^3.1.0",

--- a/packages/azure-kusto-data/package.json
+++ b/packages/azure-kusto-data/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-kusto-data",
-    "version": "7.1.0",
+    "version": "7.2.0",
     "description": "Azure Data Explorer Query SDK",
     "type": "module",
     "main": "dist-esm/src/index.js",

--- a/packages/azure-kusto-ingest/package.json
+++ b/packages/azure-kusto-ingest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-kusto-ingest",
-    "version": "7.1.0",
+    "version": "7.2.0",
     "description": "Azure Data Explorer Ingestion SDK",
     "type": "module",
     "main": "dist-esm/src/index.js",
@@ -72,7 +72,7 @@
         "@types/tmp": "^0.2.6",
         "@types/uuid": "^8.3.4",
         "@types/uuid-validate": "0.0.1",
-        "azure-kusto-data": "^7.1.0",
+        "azure-kusto-data": "^7.2.0",
         "browserify-zlib": "0.2.0",
         "buffer": "^6.0.3",
         "is-ip": "^3.1.0",


### PR DESCRIPTION
Bump azure-kusto-data and azure-kusto-ingest from 7.1.0 to 7.2.0 for release.

After merging, tag with `v7.2.0` to trigger the release workflow and publish to npm.